### PR TITLE
Unify tabs to spaces in mixed files

### DIFF
--- a/babelsberg/tests.js
+++ b/babelsberg/tests.js
@@ -1,8 +1,8 @@
 module('users.timfelgentreff.babelsberg.tests').requires(
-	'lively.TestFramework',
-	'users.timfelgentreff.babelsberg.constraintinterpreter',
-	'users.timfelgentreff.babelsberg.src_transform_test',
-	'users.timfelgentreff.reactive.reactive_test'
+    'lively.TestFramework',
+    'users.timfelgentreff.babelsberg.constraintinterpreter',
+    'users.timfelgentreff.babelsberg.src_transform_test',
+    'users.timfelgentreff.reactive.reactive_test'
 ).toRun(function() {
 
 TestCase.subclass('users.timfelgentreff.babelsberg.tests.ConstraintTest', {
@@ -1329,14 +1329,14 @@ TestCase.subclass('users.timfelgentreff.babelsberg.tests.InteractionTest', {
 
 TestCase.subclass('users.timfelgentreff.babelsberg.tests.CSPTest', {
     testBacktalkPaperExample: function () {
-	    var solver = bbb.defaultSolver = new csp.Solver();
-    	var man = {
-			shoes: "foo",
-			shirt: "foo",
-			pants: "foo",
-			hat: "foo"
-		};
-	    
+        var solver = bbb.defaultSolver = new csp.Solver();
+        var man = {
+            shoes: "foo",
+            shirt: "foo",
+            pants: "foo",
+            hat: "foo"
+        };
+        
         bbb.always({
             ctx: {
                 bbb: bbb,
@@ -1360,7 +1360,7 @@ TestCase.subclass('users.timfelgentreff.babelsberg.tests.CSPTest', {
         }, function() {
             return man.shirt.is in ["brown", "blue", "white"];;
         });
-	    
+        
         bbb.always({
             ctx: {
                 bbb: bbb,
@@ -1372,7 +1372,7 @@ TestCase.subclass('users.timfelgentreff.babelsberg.tests.CSPTest', {
         }, function() {
             return man.pants.is in ["brown", "blue", "black", "white"];;
         });
-	    
+        
         bbb.always({
             ctx: {
                 bbb: bbb,
@@ -1384,7 +1384,7 @@ TestCase.subclass('users.timfelgentreff.babelsberg.tests.CSPTest', {
         }, function() {
             return man.hat.is in ["brown"];;
         });
-	    
+        
         bbb.always({
             ctx: {
                 bbb: bbb,
@@ -1440,9 +1440,9 @@ TestCase.subclass('users.timfelgentreff.babelsberg.tests.CSPTest', {
         this.assert(man.pants === "black" || man.pants === "blue" || man.pants === "white", "pants should be 'black', 'blue' or 'white'");
     },
     testForceToDomain: function () {
-	    var solver = bbb.defaultSolver = new csp.Solver();
-	    var pt = {x: 5, y: 2};
-	    
+        var solver = bbb.defaultSolver = new csp.Solver();
+        var pt = {x: 5, y: 2};
+        
         bbb.always({
             ctx: {
                 bbb: bbb,
@@ -1455,12 +1455,12 @@ TestCase.subclass('users.timfelgentreff.babelsberg.tests.CSPTest', {
             return pt.x.is in [1, 2, 3];;
         });
 
-	    this.assert([1, 2, 3].indexOf(pt.x) > -1, "x is not in its domain [1, 2, 3], but " + pt.x);
+        this.assert([1, 2, 3].indexOf(pt.x) > -1, "x is not in its domain [1, 2, 3], but " + pt.x);
     },
     testRemainIfInDomain: function () {
-	    var solver = bbb.defaultSolver = new csp.Solver();
-	    var pt = {x: 5, y: 2};
-	    
+        var solver = bbb.defaultSolver = new csp.Solver();
+        var pt = {x: 5, y: 2};
+        
         bbb.always({
             ctx: {
                 bbb: bbb,
@@ -1473,13 +1473,13 @@ TestCase.subclass('users.timfelgentreff.babelsberg.tests.CSPTest', {
             return pt.x.is in [4, 5, 6];;
         });
 
-	    this.assert(pt.x === 5, "x does not stay at 5, but probably raims in its domain [4, 5, 6]; x: " + pt.x);
+        this.assert(pt.x === 5, "x does not stay at 5, but probably raims in its domain [4, 5, 6]; x: " + pt.x);
     },
     testErrorOnEmptyDomain: function () {
-	    var solver = bbb.defaultSolver = new csp.Solver(),
-	    	pt = {x: 5, y: 2},
-	    	errorThrown = false;
-	    
+        var solver = bbb.defaultSolver = new csp.Solver(),
+            pt = {x: 5, y: 2},
+            errorThrown = false;
+        
         bbb.always({
             ctx: {
                 bbb: bbb,
@@ -1492,18 +1492,18 @@ TestCase.subclass('users.timfelgentreff.babelsberg.tests.CSPTest', {
             return pt.x.is in [];;
         });
         try {
-		    solver.newVariable(pt, "x", []);
-	    } catch (e) {
-	    	errorThrown = true;
-	    }
+            solver.newVariable(pt, "x", []);
+        } catch (e) {
+            errorThrown = true;
+        }
 
-	    this.assert(errorThrown, "no error was thrown on empty domain");
+        this.assert(errorThrown, "no error was thrown on empty domain");
     },
     testAssignment: function () {
-	    var solver = bbb.defaultSolver = new csp.Solver(),
-	    	pt = {x: 2, y: 6},
-	    	errorThrown = false;
-	    
+        var solver = bbb.defaultSolver = new csp.Solver(),
+            pt = {x: 2, y: 6},
+            errorThrown = false;
+        
         bbb.always({
             ctx: {
                 bbb: bbb,
@@ -1527,7 +1527,7 @@ TestCase.subclass('users.timfelgentreff.babelsberg.tests.CSPTest', {
         }, function() {
             return pt.y.is in [4, 5, 6, 7, 8, 9, 10, 11, 12];;
         });
-	    
+        
         bbb.always({
             ctx: {
                 bbb: bbb,
@@ -1539,20 +1539,20 @@ TestCase.subclass('users.timfelgentreff.babelsberg.tests.CSPTest', {
         }, function() {
             return pt.x + 4 === pt.y;;
         });
-	
+    
         pt.x = 8;
         this.assert(pt.x === 8, "assignment 'x = 8' was not successful; x: " + pt.x);
-	    this.assert(pt.y === 12, "constraint 'x + 4 == y' not satisfied; y: " + pt.y);
-	    
-	    pt.y = 7;
-	    this.assert(pt.y === 7, "assignment 'y = 7' was not successful; y: " + pt.y);
-	    this.assert(pt.x === 3, "constraint 'x + 4 == y' not satisfied; x: " + pt.x);
+        this.assert(pt.y === 12, "constraint 'x + 4 == y' not satisfied; y: " + pt.y);
+        
+        pt.y = 7;
+        this.assert(pt.y === 7, "assignment 'y = 7' was not successful; y: " + pt.y);
+        this.assert(pt.x === 3, "constraint 'x + 4 == y' not satisfied; x: " + pt.x);
     },
     testAssignment2: function () {
-	    var solver = bbb.defaultSolver = new csp.Solver(),
-	    	pt = {x: 2, y: 8},
-	    	errorThrown = false;
-	    
+        var solver = bbb.defaultSolver = new csp.Solver(),
+            pt = {x: 2, y: 8},
+            errorThrown = false;
+        
         bbb.always({
             ctx: {
                 bbb: bbb,
@@ -1588,18 +1588,18 @@ TestCase.subclass('users.timfelgentreff.babelsberg.tests.CSPTest', {
         }, function() {
             return pt.x + pt.y >= 10;;
         });
-	
+    
         this.assert(pt.x + pt.y >= 10, "constraint 'pt.x + pt.y >= 10' does not hold for x: "+ pt.x+", y: " + pt.y);
 
-	    pt.y = 4;
+        pt.y = 4;
         this.assert(pt.y === 4, "assignment 'y = 4' was not successful; y: " + pt.y);
         this.assert(pt.x + pt.y >= 10, "constraint 'pt.x + pt.y >= 10' does not hold for x: "+ pt.x+", y: " + pt.y);
     },
     testFailingAssignmentOnDomain: function () {
-	    var solver = bbb.defaultSolver = new csp.Solver(),
-	    	pt = {x: 5, y: 2},
-	    	errorThrown = false;
-	    
+        var solver = bbb.defaultSolver = new csp.Solver(),
+            pt = {x: 5, y: 2},
+            errorThrown = false;
+        
         bbb.always({
             ctx: {
                 bbb: bbb,
@@ -1611,21 +1611,21 @@ TestCase.subclass('users.timfelgentreff.babelsberg.tests.CSPTest', {
         }, function() {
             return pt.x.is in [1, 2, 3];;
         });
-	    
-	    try {
-	        pt.x = 0;
-	    } catch (e) {
-	    	errorThrown = true;
-	    }
-	
-	    this.assert(errorThrown, "no error was thrown on new value x = 0 with domain [1, 2, 3]; x: " + pt.x);
+        
+        try {
+            pt.x = 0;
+        } catch (e) {
+            errorThrown = true;
+        }
+    
+        this.assert(errorThrown, "no error was thrown on new value x = 0 with domain [1, 2, 3]; x: " + pt.x);
     },
     testFailingAssignment: function () {
-    	// try x = 0 with constraint x > 4
-	    var solver = bbb.defaultSolver = new csp.Solver(),
-	    	pt = {x: 2, y: 8},
-	    	errorThrown = false;
-	    
+        // try x = 0 with constraint x > 4
+        var solver = bbb.defaultSolver = new csp.Solver(),
+            pt = {x: 2, y: 8},
+            errorThrown = false;
+        
         bbb.always({
             ctx: {
                 bbb: bbb,
@@ -1649,51 +1649,51 @@ TestCase.subclass('users.timfelgentreff.babelsberg.tests.CSPTest', {
         }, function() {
             return pt.y.is in [1, 2, 3, 4, 5, 6, 7, 8, 9];;
         });
-	    
-	    bbb.always({
-	        ctx: {
-	            bbb: bbb,
-	            csp: csp,
-	            solver: solver,
-	            pt: pt,
-	            _$_self: this.doitContext || this
-	        }
-	    }, function() {
-	        return pt.x > 4;;
-	    });
-	
-	    bbb.always({
-	        ctx: {
-	            bbb: bbb,
-	            csp: csp,
-	            solver: solver,
-	            pt: pt,
-	            _$_self: this.doitContext || this
-	        }
-	    }, function() {
-	        return pt.x + pt.y === 10;;
-	    });
+        
+        bbb.always({
+            ctx: {
+                bbb: bbb,
+                csp: csp,
+                solver: solver,
+                pt: pt,
+                _$_self: this.doitContext || this
+            }
+        }, function() {
+            return pt.x > 4;;
+        });
+    
+        bbb.always({
+            ctx: {
+                bbb: bbb,
+                csp: csp,
+                solver: solver,
+                pt: pt,
+                _$_self: this.doitContext || this
+            }
+        }, function() {
+            return pt.x + pt.y === 10;;
+        });
 
-	    this.assert(pt.x > 4, "constraint 'pt.x  > 4' does not hold for x: "+ pt.x);
-	    this.assert(pt.x + pt.y === 10, "constraint 'pt.x + pt.y === 10' does not hold for x: "+ pt.x + ", y: " + pt.y);
-	
-	    var oldValueX = pt.x;
-	    var oldValueY = pt.y;
-	    
-	    try {
-	        pt.y = 7;
-	    } catch (e) {
-	    	errorThrown = true;
-	    }
+        this.assert(pt.x > 4, "constraint 'pt.x  > 4' does not hold for x: "+ pt.x);
+        this.assert(pt.x + pt.y === 10, "constraint 'pt.x + pt.y === 10' does not hold for x: "+ pt.x + ", y: " + pt.y);
+    
+        var oldValueX = pt.x;
+        var oldValueY = pt.y;
+        
+        try {
+            pt.y = 7;
+        } catch (e) {
+            errorThrown = true;
+        }
         this.assert(errorThrown, "no error was thrown on new value y = 7 with constraints 'pt.x + pt.y === 10' and 'pt.x  > 4'; x: " + pt.x + ", y: " + pt.y);
-	    this.assert(pt.y === oldValueY, "old value of y not restored after failed assignment; currentY: " + pt.y + ", oldY: " + oldValueY);
-	    this.assert(pt.x === oldValueX, "old value of x not restored after failed assignment; currentX: " + pt.x + ", oldX: " + oldValueX);
+        this.assert(pt.y === oldValueY, "old value of y not restored after failed assignment; currentY: " + pt.y + ", oldY: " + oldValueY);
+        this.assert(pt.x === oldValueX, "old value of x not restored after failed assignment; currentX: " + pt.x + ", oldX: " + oldValueX);
     },
     testUnsatisfiableConstraint: function () {
-	    var solver = bbb.defaultSolver = new csp.Solver(),
-	    	pt = {x: 5, y: 2},
-	    	errorThrown = false;
-	    
+        var solver = bbb.defaultSolver = new csp.Solver(),
+            pt = {x: 5, y: 2},
+            errorThrown = false;
+        
         bbb.always({
             ctx: {
                 bbb: bbb,
@@ -1705,134 +1705,134 @@ TestCase.subclass('users.timfelgentreff.babelsberg.tests.CSPTest', {
         }, function() {
             return pt.x.is in [1, 2, 3];;
         });
-	    
-	    try {
-	        bbb.always({
-	            ctx: {
-	                bbb: bbb,
-	                csp: csp,
-	                solver: solver,
-	                pt: pt,
-	                _$_self: this.doitContext || this
-	            }
-	        }, function() {
-	            return pt.x >= 5;;
-	        });
-	    } catch (e) {
-	    	errorThrown = true;
-	    }
-	
-	    this.assert(errorThrown, "no error was thrown on unsatisfiable constraint");
+        
+        try {
+            bbb.always({
+                ctx: {
+                    bbb: bbb,
+                    csp: csp,
+                    solver: solver,
+                    pt: pt,
+                    _$_self: this.doitContext || this
+                }
+            }, function() {
+                return pt.x >= 5;;
+            });
+        } catch (e) {
+            errorThrown = true;
+        }
+    
+        this.assert(errorThrown, "no error was thrown on unsatisfiable constraint");
     }
 });
 
 TestCase.subclass('users.timfelgentreff.babelsberg.tests.OnErrorTest', {
     testOnErrorCassowaryConstraintConstruction: function () {
         var obj = {a: 0},
-			onErrorCalled = false;
+            onErrorCalled = false;
 
-		bbb.defaultSolver = new ClSimplexSolver();
-		
-		bbb.always({
-			onError: function() {
-				onErrorCalled = true;
-			},
-			ctx: {
-				bbb: bbb,
-				obj: obj,
-				_$_self: this.doitContext || this
-			}
-		}, function() {
-			return obj.a == 0;;
-		});
+        bbb.defaultSolver = new ClSimplexSolver();
+        
+        bbb.always({
+            onError: function() {
+                onErrorCalled = true;
+            },
+            ctx: {
+                bbb: bbb,
+                obj: obj,
+                _$_self: this.doitContext || this
+            }
+        }, function() {
+            return obj.a == 0;;
+        });
 
-		bbb.always({
-			onError: function() {
-				onErrorCalled = true;
-			},
-			ctx: {
-				bbb: bbb,
-				obj: obj,
-				_$_self: this.doitContext || this
-			}
-		}, function() {
-			return obj.a == 10;;
-		});
-	
-		this.assert(onErrorCalled, "onError was not called; obj.a: " + obj.a);
+        bbb.always({
+            onError: function() {
+                onErrorCalled = true;
+            },
+            ctx: {
+                bbb: bbb,
+                obj: obj,
+                _$_self: this.doitContext || this
+            }
+        }, function() {
+            return obj.a == 10;;
+        });
+    
+        this.assert(onErrorCalled, "onError was not called; obj.a: " + obj.a);
     },
     testOnErrorCassowaryAssignment: function () {
         var obj = {a: 0},
-			onErrorCalled = false;
+            onErrorCalled = false;
 
-		bbb.defaultSolver = new ClSimplexSolver();
-		
-		bbb.always({
-			onError: function() {
-				onErrorCalled = true;
-			},
-			ctx: {
-				bbb: bbb,
-				obj: obj,
-				_$_self: this.doitContext || this
-			}
-		}, function() {
-			return obj.a == 0;;
-		});
+        bbb.defaultSolver = new ClSimplexSolver();
+        
+        bbb.always({
+            onError: function() {
+                onErrorCalled = true;
+            },
+            ctx: {
+                bbb: bbb,
+                obj: obj,
+                _$_self: this.doitContext || this
+            }
+        }, function() {
+            return obj.a == 0;;
+        });
 
-		obj.a = 10;
-		
-		this.assert(onErrorCalled, "onError was not called; obj.a: " + obj.a);
+        obj.a = 10;
+        
+        this.assert(onErrorCalled, "onError was not called; obj.a: " + obj.a);
     },
     _testOnErrorDeltaBlueConstraintConstruction: function () {
         var obj = {int: 17, str: "17"},
-			onErrorCalled = false;
+            onErrorCalled = false;
 
-		bbb.defaultSolver = new DBPlanner();
-		
-		bbb.always({
-			onError: function() {
-				onErrorCalled = true;
-			},
-			ctx: {
-				obj: obj
-			}, methods: function() {
-				obj.int.formula([obj.str], function (str) { return parseInt(str); });
-				obj.str.formula([obj.int], function (int) { return int + ""; })
-			}
-		}, function () {
-			return obj.int + "" === obj.str;
-		});
-		bbb.always({
-			onError: function() {
-				onErrorCalled = true;
-			},
-			ctx: {
-				obj: obj
-			}, methods: function() {
-				obj.int.formula([obj.str], function (str) { return parseInt(str)-1; });
-				obj.str.formula([obj.int], function (int) { return (int+1) + ""; })
-			}
-		}, function () {
-			return (obj.int+1) + "" === obj.str;
-		});
+        bbb.defaultSolver = new DBPlanner();
+        
+        bbb.always({
+            onError: function() {
+                onErrorCalled = true;
+            },
+            ctx: {
+                obj: obj
+            }, methods: function() {
+                obj.int.formula([obj.str], function (str) { return parseInt(str); });
+                obj.str.formula([obj.int], function (int) { return int + ""; })
+            }
+        }, function () {
+            return obj.int + "" === obj.str;
+        });
+        bbb.always({
+            onError: function() {
+                onErrorCalled = true;
+            },
+            ctx: {
+                obj: obj
+            }, methods: function() {
+                obj.int.formula([obj.str], function (str) { return parseInt(str)-1; });
+                obj.str.formula([obj.int], function (int) { return (int+1) + ""; })
+            }
+        }, function () {
+            return (obj.int+1) + "" === obj.str;
+        });
 
-		obj.str = "10";
-		
-		this.assert(onErrorCalled, "onError was not called; obj.a: " + obj.a);
+        obj.str = "10";
+        
+        this.assert(onErrorCalled, "onError was not called; obj.a: " + obj.a);
     },
     testOnErrorCSPConstraintConstruction: function () {
         var pt = {x: 5, y: 2},
-			onErrorCalled = false,
-			errorMessage = "";
+            onErrorCalled = false,
+            errorMessage = "";
 
-		bbb.defaultSolver = new csp.Solver();
-	    
+        bbb.defaultSolver = new csp.Solver();
+        
         bbb.always({
-			onError: function(e) {
-				onErrorCalled = true;
-				errorMessage = e.message;
-			},
+            onError: function(e) {
+                onErrorCalled = true;
+                errorMessage = e.message;
+            },
             ctx: {
                 pt: pt,
                 _$_self: this.doitContext || this
@@ -1840,35 +1840,35 @@ TestCase.subclass('users.timfelgentreff.babelsberg.tests.OnErrorTest', {
         }, function() {
             return pt.x.is in [1, 2, 3];;
         });
-	    
-		bbb.always({
-			onError: function(e) {
-				onErrorCalled = true;
-				errorMessage = e.message;
-			},
-			ctx: {
-				pt: pt,
-				_$_self: this.doitContext || this
-			}
-		}, function() {
-			return pt.x >= 5;;
-		});
-	
-	    this.assert(onErrorCalled, "onError was not called");
-	    this.assert(errorMessage === "constraint cannot be satisfied", "an unexpected error was thrown, message: " + errorMessage);
+        
+        bbb.always({
+            onError: function(e) {
+                onErrorCalled = true;
+                errorMessage = e.message;
+            },
+            ctx: {
+                pt: pt,
+                _$_self: this.doitContext || this
+            }
+        }, function() {
+            return pt.x >= 5;;
+        });
+    
+        this.assert(onErrorCalled, "onError was not called");
+        this.assert(errorMessage === "constraint cannot be satisfied", "an unexpected error was thrown, message: " + errorMessage);
     },
     testOnErrorCSPAssignment: function () {
         var pt = {x: 1, y: 2},
-			onErrorCalled = false,
-			errorMessage = "";
+            onErrorCalled = false,
+            errorMessage = "";
 
-		bbb.defaultSolver = new csp.Solver();
-	    
+        bbb.defaultSolver = new csp.Solver();
+        
         bbb.always({
-			onError: function(e) {
-				onErrorCalled = true;
-				errorMessage = e.message;
-			},
+            onError: function(e) {
+                onErrorCalled = true;
+                errorMessage = e.message;
+            },
             ctx: {
                 pt: pt,
                 _$_self: this.doitContext || this
@@ -1877,25 +1877,25 @@ TestCase.subclass('users.timfelgentreff.babelsberg.tests.OnErrorTest', {
             return pt.x.is in [1, 2, 3];;
         });
 
-	    this.assert(!onErrorCalled, "onError called unexpectedly");
+        this.assert(!onErrorCalled, "onError called unexpectedly");
 
-		pt.x = 5;
-	
-	    this.assert(onErrorCalled, "onError was not called");
-	    this.assert(errorMessage === "assigned value is not contained in domain", "an unexpected error was thrown, message: " + errorMessage);
+        pt.x = 5;
+    
+        this.assert(onErrorCalled, "onError was not called");
+        this.assert(errorMessage === "assigned value is not contained in domain", "an unexpected error was thrown, message: " + errorMessage);
     },
     testOnErrorRelaxConstraintConstruction: function () {
         var pt = {x: 5},
-			onErrorCalled = false,
-			errorMessage = "";
+            onErrorCalled = false,
+            errorMessage = "";
 
-		bbb.defaultSolver = new Relax();
-	    
+        bbb.defaultSolver = new Relax();
+        
         bbb.always({
-			onError: function(e) {
-				onErrorCalled = true;
-				errorMessage = e.message;
-			},
+            onError: function(e) {
+                onErrorCalled = true;
+                errorMessage = e.message;
+            },
             ctx: {
                 pt: pt,
                 _$_self: this.doitContext || this
@@ -1903,31 +1903,31 @@ TestCase.subclass('users.timfelgentreff.babelsberg.tests.OnErrorTest', {
         }, function() {
             return pt.x == 5;;
         });
-	    
-		bbb.always({
-			onError: function(e) {
-				onErrorCalled = true;
-				errorMessage = e.message;
-			},
-			ctx: {
-				pt: pt,
-				_$_self: this.doitContext || this
-			}
-		}, function() {
-			return pt.x >= 20;;
-		});
-	
-	    this.assert(onErrorCalled, "onError was not called");
-	    this.assert(errorMessage === "Could not satisfy constraint", "an unexpected error was thrown, message: " + errorMessage);
+        
+        bbb.always({
+            onError: function(e) {
+                onErrorCalled = true;
+                errorMessage = e.message;
+            },
+            ctx: {
+                pt: pt,
+                _$_self: this.doitContext || this
+            }
+        }, function() {
+            return pt.x >= 20;;
+        });
+    
+        this.assert(onErrorCalled, "onError was not called");
+        this.assert(errorMessage === "Could not satisfy constraint", "an unexpected error was thrown, message: " + errorMessage);
     }
 });
 
 TestCase.subclass('users.timfelgentreff.babelsberg.tests.AutomaticSolverSelectionTest', {
-	setUp: function () {
+    setUp: function () {
         bbb.defaultSolvers = [new ClSimplexSolver(), new DBPlanner(), new csp.Solver()];
         bbb.defaultSolver = null;
-	},
-	testSimpleConstraintWithoutSolver: function () {
+    },
+    testSimpleConstraintWithoutSolver: function () {
         var obj = {a: 2, b: 3};
         bbb.always({
             ctx: {
@@ -1937,7 +1937,7 @@ TestCase.subclass('users.timfelgentreff.babelsberg.tests.AutomaticSolverSelectio
             return obj.a + obj.b == 3;
         });
         this.assert(obj.a + obj.b == 3, "Automatic solver selection did not produce a working solution");
-	},
+    },
     testSimplePropagationShouldChooseDeltaBlue: function() {
         var o = {string: "0",
                  number: 0};
@@ -1960,13 +1960,13 @@ TestCase.subclass('users.timfelgentreff.babelsberg.tests.AutomaticSolverSelectio
         this.assert(o.string === "12");
     },
     testBacktalkPaperExampleWithAutomaticSolverSelection: function () {
-    	var man = {
-			shoes: "foo",
-			shirt: "foo",
-			pants: "foo",
-			hat: "foo"
-		};
-	    
+        var man = {
+            shoes: "foo",
+            shirt: "foo",
+            pants: "foo",
+            hat: "foo"
+        };
+        
         bbb.always({
             ctx: {
                 bbb: bbb,
@@ -1988,7 +1988,7 @@ TestCase.subclass('users.timfelgentreff.babelsberg.tests.AutomaticSolverSelectio
         }, function() {
             return man.shirt.is in ["brown", "blue", "white"];;
         });
-	    
+        
         bbb.always({
             ctx: {
                 bbb: bbb,
@@ -1999,7 +1999,7 @@ TestCase.subclass('users.timfelgentreff.babelsberg.tests.AutomaticSolverSelectio
         }, function() {
             return man.pants.is in ["brown", "blue", "black", "white"];;
         });
-	    
+        
         bbb.always({
             ctx: {
                 bbb: bbb,
@@ -2010,7 +2010,7 @@ TestCase.subclass('users.timfelgentreff.babelsberg.tests.AutomaticSolverSelectio
         }, function() {
             return man.hat.is in ["brown"];;
         });
-	    
+        
         bbb.always({
             ctx: {
                 bbb: bbb,

--- a/backtalk/backtalk.js
+++ b/backtalk/backtalk.js
@@ -160,9 +160,9 @@ backtalk.Object.subclass('backtalk.Solver', {
         }
         this.sortedConstraintsForPropagation().detect(function (constraint) {
             this.propagateInstantiationFor(constraint);
-		    if (constraint.domainWipedOut()) {
-		        return true;
-		    }
+            if (constraint.domainWipedOut()) {
+                return true;
+            }
         }.bind(this));
     },
     sortedConstraintsForPropagation: function() {
@@ -275,16 +275,16 @@ backtalk.Object.subclass('backtalk.Context', {
     },
     fromSolver: function(solver) {
         this.valuesToExploreDict = {keys: []};
-		this.currentValuesDict = {keys: []};
-	    solver.variables().each(function (v) {
-	        this.valuesToExploreDict[v.uuid] = v.valuesToExplore.slice();
-	        this.valuesToExploreDict.keys.push(v);
-	        if (v.isInstantiated()) {
-	            this.currentValuesDict[v.uuid] = v.currentValue;
-	            this.currentValuesDict.keys.push(v);
-	        }
-	    }.bind(this));
-	    this.currentVariable = solver.currentVariable;
+        this.currentValuesDict = {keys: []};
+        solver.variables().each(function (v) {
+            this.valuesToExploreDict[v.uuid] = v.valuesToExplore.slice();
+            this.valuesToExploreDict.keys.push(v);
+            if (v.isInstantiated()) {
+                this.currentValuesDict[v.uuid] = v.currentValue;
+                this.currentValuesDict.keys.push(v);
+            }
+        }.bind(this));
+        this.currentVariable = solver.currentVariable;
     },
     restoreInSolver: function(solver) {
         this.valuesToExploreDict.keys.each(function (v) {

--- a/backtalk/tests.js
+++ b/backtalk/tests.js
@@ -5,10 +5,10 @@ TestCase.subclass('backtalk.VariableTest', {
         this.variable = backtalk.Variable.labelFromTo('x', 1, 3);
     },
     testConnectionBetweenValuesToExploreAndCurrentValue: function () {
-	    this.variable.currentValue = 2;
-	    this.variable.valuesToExplore = [];
-    	this.assert(this.variable.valuesToExplore.length === 0);
-    	this.assert(!this.variable.currentValue);
+        this.variable.currentValue = 2;
+        this.variable.valuesToExplore = [];
+        this.assert(this.variable.valuesToExplore.length === 0);
+        this.assert(!this.variable.currentValue);
     }
 });
 
@@ -29,13 +29,13 @@ TestCase.subclass('backtalk.BinaryConstraintTest', {
     },
     testReferencesAfterVariableRemoval: function() {
         var expectedConstraints, expectedVariables, newVariable;
-	    newVariable = new backtalk.Variable('x', 1, 2);
-	    this.constraint.variableA = newVariable;
-	    expectedConstraints = [this.constraint];
-    	expectedVariables = [this.variable2, newVariable];
-	    this.assert(this.variable1.constraints.length === 0);
-    	this.assert(this.variable2.constraints.equals(expectedConstraints));
-    	this.assert(this.constraint.variables().intersect(expectedVariables).length === expectedVariables.length);
+        newVariable = new backtalk.Variable('x', 1, 2);
+        this.constraint.variableA = newVariable;
+        expectedConstraints = [this.constraint];
+        expectedVariables = [this.variable2, newVariable];
+        this.assert(this.variable1.constraints.length === 0);
+        this.assert(this.variable2.constraints.equals(expectedConstraints));
+        this.assert(this.constraint.variables().intersect(expectedVariables).length === expectedVariables.length);
     }
 });
 backtalk.BinaryConstraintTest.subclass('backtalk.CSPTest', {
@@ -52,23 +52,23 @@ backtalk.CSPTest.subclass('backtalk.SolverTest', {
     setUp: function($super) {
         $super();
         this.csp.addVariable(this.variable3);
-    	this.csp.addVariable(this.variable4);
-    	this.solver = new backtalk.SolverForTest(this.csp)
-    	this.solver.reset();
+        this.csp.addVariable(this.variable4);
+        this.solver = new backtalk.SolverForTest(this.csp)
+        this.solver.reset();
     },
     testAllSolutionsOnATrivialCSP: function() {
-	    var expectedSolution,solutions;
-    	this.variable1.domain = [3]
-    	this.variable2.domain = [3]
-    	this.variable3.domain = [6]
-    	this.variable4.domain = [6]
-    	solutions = this.solver.allSolutions();
-    	this.assert(solutions.length === 1)
-    	this.assert(solutions[0].keys.equals([this.variable1, this.variable2, this.variable3, this.variable4]));
-    	this.assert(solutions[0][this.variable1.uuid] === 3)
-    	this.assert(solutions[0][this.variable2.uuid] === 3)
-    	this.assert(solutions[0][this.variable3.uuid] === 6)
-    	this.assert(solutions[0][this.variable4.uuid] === 6)
+        var expectedSolution,solutions;
+        this.variable1.domain = [3]
+        this.variable2.domain = [3]
+        this.variable3.domain = [6]
+        this.variable4.domain = [6]
+        solutions = this.solver.allSolutions();
+        this.assert(solutions.length === 1)
+        this.assert(solutions[0].keys.equals([this.variable1, this.variable2, this.variable3, this.variable4]));
+        this.assert(solutions[0][this.variable1.uuid] === 3)
+        this.assert(solutions[0][this.variable2.uuid] === 3)
+        this.assert(solutions[0][this.variable3.uuid] === 6)
+        this.assert(solutions[0][this.variable4.uuid] === 6)
     },
     testAllSolutions: function() {
         var solutions, v1, v2, v3, v4;
@@ -88,7 +88,7 @@ backtalk.CSPTest.subclass('backtalk.SolverTest', {
 
 backtalk.Solver.subclass('backtalk.SolverForTest', {
     propagateInstantiationFor: function(constraint) {
-	    return constraint.enforceArcConsistency();
+        return constraint.enforceArcConsistency();
     }
 });
 
@@ -126,14 +126,14 @@ TestCase.subclass('backtalk.BabelsbergTest', {
         delete bbb.defaultSolver;
     },
     testBacktalkPaperExample: function () {
-	    var solver = bbb.defaultSolver = new BacktalkSolver();
-    	var man = {
-			shoes: "foo",
-			shirt: "foo",
-			pants: "foo",
-			hat: "foo"
-		};
-	    
+        var solver = bbb.defaultSolver = new BacktalkSolver();
+        var man = {
+            shoes: "foo",
+            shirt: "foo",
+            pants: "foo",
+            hat: "foo"
+        };
+        
         bbb.always({
             ctx: {
                 bbb: bbb,
@@ -157,7 +157,7 @@ TestCase.subclass('backtalk.BabelsbergTest', {
         }, function() {
             return man.shirt.is in ["brown", "blue", "white"];;
         });
-	    
+        
         bbb.always({
             ctx: {
                 bbb: bbb,
@@ -169,7 +169,7 @@ TestCase.subclass('backtalk.BabelsbergTest', {
         }, function() {
             return man.pants.is in ["brown", "blue", "black", "white"];;
         });
-	    
+        
         bbb.always({
             ctx: {
                 bbb: bbb,
@@ -237,9 +237,9 @@ TestCase.subclass('backtalk.BabelsbergTest', {
         this.assert(man.pants === "black" || man.pants === "blue" || man.pants === "white", "pants should be 'black', 'blue' or 'white'");
     },
     testForceToDomain: function () {
-	    var solver = bbb.defaultSolver = new BacktalkSolver();
-	    var pt = {x: 5, y: 2};
-	    
+        var solver = bbb.defaultSolver = new BacktalkSolver();
+        var pt = {x: 5, y: 2};
+        
         bbb.always({
             ctx: {
                 bbb: bbb,
@@ -252,12 +252,12 @@ TestCase.subclass('backtalk.BabelsbergTest', {
             return pt.x.is in [1, 2, 3];;
         });
 
-	    this.assert([1, 2, 3].indexOf(pt.x) > -1, "x is not in its domain [1, 2, 3], but " + pt.x);
+        this.assert([1, 2, 3].indexOf(pt.x) > -1, "x is not in its domain [1, 2, 3], but " + pt.x);
     },
     testRemainIfInDomain: function () {
-	    var solver = bbb.defaultSolver = new BacktalkSolver();
-	    var pt = {x: 5, y: 2};
-	    
+        var solver = bbb.defaultSolver = new BacktalkSolver();
+        var pt = {x: 5, y: 2};
+        
         bbb.always({
             ctx: {
                 bbb: bbb,
@@ -270,14 +270,14 @@ TestCase.subclass('backtalk.BabelsbergTest', {
             return pt.x.is in [4, 5, 6];;
         });
 
-	    this.assert(pt.x === 5, "x does not stay at 5, but probably raims in its domain [4, 5, 6]; x: " + pt.x);
+        this.assert(pt.x === 5, "x does not stay at 5, but probably raims in its domain [4, 5, 6]; x: " + pt.x);
     },
     testErrorOnEmptyDomain: function () {
-	    var solver = bbb.defaultSolver = new BacktalkSolver();
-	    	p = {x: 5, y: 2},
-	    	errorThrown = false;
-	    
-	    try {
+        var solver = bbb.defaultSolver = new BacktalkSolver();
+            p = {x: 5, y: 2},
+            errorThrown = false;
+        
+        try {
             bbb.always({
                 ctx: {
                     bbb: bbb,
@@ -293,13 +293,13 @@ TestCase.subclass('backtalk.BabelsbergTest', {
             errorThrown = true;
         }
 
-	    this.assert(errorThrown, "no error was thrown on empty domain");
+        this.assert(errorThrown, "no error was thrown on empty domain");
     },
     testAssignment: function () {
-	    var solver = bbb.defaultSolver = new BacktalkSolver(),
-	    	pt = {x: 2, y: 6},
-	    	errorThrown = false;
-	    
+        var solver = bbb.defaultSolver = new BacktalkSolver(),
+            pt = {x: 2, y: 6},
+            errorThrown = false;
+        
         bbb.always({
             ctx: {
                 bbb: bbb,
@@ -323,7 +323,7 @@ TestCase.subclass('backtalk.BabelsbergTest', {
         }, function() {
             return pt.y.is in [4, 5, 6, 7, 8, 9, 10, 11, 12];;
         });
-	    
+        
         bbb.always({
             ctx: {
                 bbb: bbb,
@@ -335,20 +335,20 @@ TestCase.subclass('backtalk.BabelsbergTest', {
         }, function() {
             return pt.x + 4 === pt.y;;
         });
-	
+    
         pt.x = 8;
         this.assert(pt.x === 8, "assignment 'x = 8' was not successful; x: " + pt.x);
-	    this.assert(pt.y === 12, "constraint 'x + 4 == y' not satisfied; y: " + pt.y);
-	    
-	    pt.y = 7;
-	    this.assert(pt.y === 7, "assignment 'y = 7' was not successful; y: " + pt.y);
-	    this.assert(pt.x === 3, "constraint 'x + 4 == y' not satisfied; x: " + pt.x);
+        this.assert(pt.y === 12, "constraint 'x + 4 == y' not satisfied; y: " + pt.y);
+        
+        pt.y = 7;
+        this.assert(pt.y === 7, "assignment 'y = 7' was not successful; y: " + pt.y);
+        this.assert(pt.x === 3, "constraint 'x + 4 == y' not satisfied; x: " + pt.x);
     },
     testAssignment2: function () {
-	    var solver = bbb.defaultSolver = new BacktalkSolver(),
-	    	pt = {x: 2, y: 8},
-	    	errorThrown = false;
-	    
+        var solver = bbb.defaultSolver = new BacktalkSolver(),
+            pt = {x: 2, y: 8},
+            errorThrown = false;
+        
         bbb.always({
             ctx: {
                 bbb: bbb,
@@ -384,18 +384,18 @@ TestCase.subclass('backtalk.BabelsbergTest', {
         }, function() {
             return pt.x + pt.y >= 10;;
         });
-	
+    
         this.assert(pt.x + pt.y >= 10, "constraint 'pt.x + pt.y >= 10' does not hold for x: "+ pt.x+", y: " + pt.y);
 
-	    pt.y = 4;
+        pt.y = 4;
         this.assert(pt.y === 4, "assignment 'y = 4' was not successful; y: " + pt.y);
         this.assert(pt.x + pt.y >= 10, "constraint 'pt.x + pt.y >= 10' does not hold for x: "+ pt.x+", y: " + pt.y);
     },
     testFailingAssignmentOnDomain: function () {
-	    var solver = bbb.defaultSolver = new BacktalkSolver(),
-	    	pt = {x: 5, y: 2},
-	    	errorThrown = false;
-	    
+        var solver = bbb.defaultSolver = new BacktalkSolver(),
+            pt = {x: 5, y: 2},
+            errorThrown = false;
+        
         bbb.always({
             ctx: {
                 bbb: bbb,
@@ -407,21 +407,21 @@ TestCase.subclass('backtalk.BabelsbergTest', {
         }, function() {
             return pt.x.is in [1, 2, 3];;
         });
-	    
-	    try {
-	        pt.x = 0;
-	    } catch (e) {
-	    	errorThrown = true;
-	    }
-	
-	    this.assert(errorThrown, "no error was thrown on new value x = 0 with domain [1, 2, 3]; x: " + pt.x);
+        
+        try {
+            pt.x = 0;
+        } catch (e) {
+            errorThrown = true;
+        }
+    
+        this.assert(errorThrown, "no error was thrown on new value x = 0 with domain [1, 2, 3]; x: " + pt.x);
     },
     testFailingAssignment: function () {
-    	// try x = 0 with constraint x > 4
-	    var solver = bbb.defaultSolver = new BacktalkSolver(),
-	    	pt = {x: 2, y: 8},
-	    	errorThrown = false;
-	    
+        // try x = 0 with constraint x > 4
+        var solver = bbb.defaultSolver = new BacktalkSolver(),
+            pt = {x: 2, y: 8},
+            errorThrown = false;
+        
         bbb.always({
             ctx: {
                 bbb: bbb,
@@ -445,51 +445,51 @@ TestCase.subclass('backtalk.BabelsbergTest', {
         }, function() {
             return pt.y.is in [1, 2, 3, 4, 5, 6, 7, 8, 9];;
         });
-	    
-	    bbb.always({
-	        ctx: {
-	            bbb: bbb,
-	            csp: csp,
-	            solver: solver,
-	            pt: pt,
-	            _$_self: this.doitContext || this
-	        }
-	    }, function() {
-	        return pt.x > 4;;
-	    });
-	
-	    bbb.always({
-	        ctx: {
-	            bbb: bbb,
-	            csp: csp,
-	            solver: solver,
-	            pt: pt,
-	            _$_self: this.doitContext || this
-	        }
-	    }, function() {
-	        return pt.x + pt.y === 10;;
-	    });
+        
+        bbb.always({
+            ctx: {
+                bbb: bbb,
+                csp: csp,
+                solver: solver,
+                pt: pt,
+                _$_self: this.doitContext || this
+            }
+        }, function() {
+            return pt.x > 4;;
+        });
+    
+        bbb.always({
+            ctx: {
+                bbb: bbb,
+                csp: csp,
+                solver: solver,
+                pt: pt,
+                _$_self: this.doitContext || this
+            }
+        }, function() {
+            return pt.x + pt.y === 10;;
+        });
 
-	    this.assert(pt.x > 4, "constraint 'pt.x  > 4' does not hold for x: "+ pt.x);
-	    this.assert(pt.x + pt.y === 10, "constraint 'pt.x + pt.y === 10' does not hold for x: "+ pt.x + ", y: " + pt.y);
-	
-	    var oldValueX = pt.x;
-	    var oldValueY = pt.y;
-	    
-	    try {
-	        pt.y = 7;
-	    } catch (e) {
-	    	errorThrown = true;
-	    }
+        this.assert(pt.x > 4, "constraint 'pt.x  > 4' does not hold for x: "+ pt.x);
+        this.assert(pt.x + pt.y === 10, "constraint 'pt.x + pt.y === 10' does not hold for x: "+ pt.x + ", y: " + pt.y);
+    
+        var oldValueX = pt.x;
+        var oldValueY = pt.y;
+        
+        try {
+            pt.y = 7;
+        } catch (e) {
+            errorThrown = true;
+        }
         this.assert(errorThrown, "no error was thrown on new value y = 7 with constraints 'pt.x + pt.y === 10' and 'pt.x  > 4'; x: " + pt.x + ", y: " + pt.y);
-	    this.assert(pt.y === oldValueY, "old value of y not restored after failed assignment; currentY: " + pt.y + ", oldY: " + oldValueY);
-	    this.assert(pt.x === oldValueX, "old value of x not restored after failed assignment; currentX: " + pt.x + ", oldX: " + oldValueX);
+        this.assert(pt.y === oldValueY, "old value of y not restored after failed assignment; currentY: " + pt.y + ", oldY: " + oldValueY);
+        this.assert(pt.x === oldValueX, "old value of x not restored after failed assignment; currentX: " + pt.x + ", oldX: " + oldValueX);
     },
     testUnsatisfiableConstraint: function () {
-	    var solver = bbb.defaultSolver = new BacktalkSolver(),
-	    	pt = {x: 5, y: 2},
-	    	errorThrown = false;
-	    
+        var solver = bbb.defaultSolver = new BacktalkSolver(),
+            pt = {x: 5, y: 2},
+            errorThrown = false;
+        
         bbb.always({
             ctx: {
                 bbb: bbb,
@@ -501,24 +501,24 @@ TestCase.subclass('backtalk.BabelsbergTest', {
         }, function() {
             return pt.x.is in [1, 2, 3];;
         });
-	    
-	    try {
-	        bbb.always({
-	            ctx: {
-	                bbb: bbb,
-	                csp: csp,
-	                solver: solver,
-	                pt: pt,
-	                _$_self: this.doitContext || this
-	            }
-	        }, function() {
-	            return pt.x >= 5;;
-	        });
-	    } catch (e) {
-	    	errorThrown = true;
-	    }
-	
-	    this.assert(errorThrown, "no error was thrown on unsatisfiable constraint");
+        
+        try {
+            bbb.always({
+                ctx: {
+                    bbb: bbb,
+                    csp: csp,
+                    solver: solver,
+                    pt: pt,
+                    _$_self: this.doitContext || this
+                }
+            }, function() {
+                return pt.x >= 5;;
+            });
+        } catch (e) {
+            errorThrown = true;
+        }
+    
+        this.assert(errorThrown, "no error was thrown on unsatisfiable constraint");
     }
 })
 

--- a/borning/playground.js
+++ b/borning/playground.js
@@ -33,7 +33,7 @@ TestCase.subclass('users.borning.playground.PlaygroundTests', {
         //    // debugging: true
         //    solver: new ClSimplexSolver()
         //    p1.addPt(p2).equals(p3) && p1.equals(pt(100,300))  &&
-        //	p3.x==45 && p3.y==500;
+        //    p3.x==45 && p3.y==500;
         //    } 
     },
     testEquals: function() {

--- a/jsinterpreter/Parser.js
+++ b/jsinterpreter/Parser.js
@@ -704,11 +704,11 @@ users.timfelgentreff.jsinterpreter.Parser.jsParser = LivelyJSParser;',
     'break': {
         className: 'Break', rules: [':pos', 'trans:label'],
         initializing: {
-          	initialize: function($super, pos, label) {
-            		this.pos = pos;
-            		this.label = label || new users.timfelgentreff.jsinterpreter.Label([pos[1], pos[1]], '');
-            		this.label.setParent(this);
-          	},
+              initialize: function($super, pos, label) {
+                    this.pos = pos;
+                    this.label = label || new users.timfelgentreff.jsinterpreter.Label([pos[1], pos[1]], '');
+                    this.label.setParent(this);
+              },
         },
         debugging: {
             printConstruction: function() { return this.printConstructorCall(this.pos, this.label) },
@@ -731,11 +731,11 @@ users.timfelgentreff.jsinterpreter.Parser.jsParser = LivelyJSParser;',
     'continue': {
         className: 'Continue', rules: [':pos', 'trans:label'],
         initializing: {
-          	initialize: function($super, pos, label) {
-            		this.pos = pos;
-            		this.label = label || new users.timfelgentreff.jsinterpreter.Label([pos[1], pos[1]], '');
-            		this.label.setParent(this);
-          	},
+              initialize: function($super, pos, label) {
+                    this.pos = pos;
+                    this.label = label || new users.timfelgentreff.jsinterpreter.Label([pos[1], pos[1]], '');
+                    this.label.setParent(this);
+              },
         },
         debugging: {
             printConstruction: function() { return this.printConstructorCall(this.pos, this.label) },

--- a/jsinterpreter/generated/Nodes.js
+++ b/jsinterpreter/generated/Nodes.js
@@ -3,32 +3,32 @@ Object.subclass('users.timfelgentreff.jsinterpreter.Node');
 
 users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpreter.Sequence',
 'testing', {
-	isSequence: true,
+    isSequence: true,
 },
 'initializing', {
-	initialize: function($super, pos, children) {
-		this.pos = pos;
-		this.children = children;
-		children.forEach(function(node) { node.setParent(this) }, this);
-	},
+    initialize: function($super, pos, children) {
+        this.pos = pos;
+        this.children = children;
+        children.forEach(function(node) { node.setParent(this) }, this);
+    },
 },
 'debugging', {
-	printConstruction: function () { return this.printConstructorCall(this.pos, this.children) },
-	toString: function () {
+    printConstruction: function () { return this.printConstructorCall(this.pos, this.children) },
+    toString: function () {
                 return Strings.format(
                     '%s(%s)',
                     this.constructor.name, this.children.join(','))
             },
 },
 'conversion', {
-	asJS: function (depth) {
+    asJS: function (depth) {
                 var indent = this.indent(depth || 0);
                 depth = depth || -1;
                 return this.children.invoke('asJS', depth + 1).join(';\n' + indent);
             },
 },
 'insertion', {
-	insertBefore: function (newNode, existingNode) {
+    insertBefore: function (newNode, existingNode) {
                 for (var i = 0; i < this.children.length; i++)
                     if (this.children[i].nodesMatching(function(node) {
                         return node === existingNode }).length > 0)
@@ -37,28 +37,28 @@ users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpr
                     throw dbgOn(new Error('insertBefore: ' + existingNode + ' not in ' + this));
                 return this.insertAt(newNode, i);
             },
-	insertAt: function (newNode, idx) {
+    insertAt: function (newNode, idx) {
                 this.children.pushAt(newNode, idx);
                 newNode.setParent(this);
                 return newNode;
             },
 },
 'accessing', {
-	parentSequence: function () { return this },
+    parentSequence: function () { return this },
 },
 'stepping', {
-	firstStatement: function () {
+    firstStatement: function () {
                 return this.children.length > 0
                      ? this.children[0].firstStatement()
                      : this;
             },
-	nextStatement: function ($super, node) {
+    nextStatement: function ($super, node) {
                 var idx = this.children.indexOf(node);
                 if (idx >= 0 && idx < this.children.length - 1)
                     return this.children[idx + 1];
                 return $super(this);
             },
-	isComposite: function () {
+    isComposite: function () {
                 return true;
             },
 },
@@ -70,21 +70,21 @@ users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpr
 
 users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpreter.Number',
 'testing', {
-	isNumber: true,
+    isNumber: true,
 },
 'initializing', {
-	initialize: function($super, pos, value) {
-		this.pos = pos;
-		this.value = value;
+    initialize: function($super, pos, value) {
+        this.pos = pos;
+        this.value = value;
 
-	},
+    },
 },
 'debugging', {
-	printConstruction: function () { return this.printConstructorCall(this.pos, this.pos, this.value) },
-	toString: function () { return Strings.format('%s(%s)', this.constructor.name, this.value) },
+    printConstruction: function () { return this.printConstructorCall(this.pos, this.pos, this.value) },
+    toString: function () { return Strings.format('%s(%s)', this.constructor.name, this.value) },
 },
 'conversion', {
-	asJS: function (depth) { return this.value },
+    asJS: function (depth) { return this.value },
 },
 'visiting', {
     accept: function(visitor) {
@@ -94,21 +94,21 @@ users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpr
 
 users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpreter.String',
 'testing', {
-	isString: true,
+    isString: true,
 },
 'initializing', {
-	initialize: function($super, pos, value) {
-		this.pos = pos;
-		this.value = value;
+    initialize: function($super, pos, value) {
+        this.pos = pos;
+        this.value = value;
 
-	},
+    },
 },
 'debugging', {
-	printConstruction: function () { return this.printConstructorCall(this.pos, '"' + this.value + '"') },
-	toString: function () { return Strings.format('%s(%s)', this.constructor.name, this.value) },
+    printConstruction: function () { return this.printConstructorCall(this.pos, '"' + this.value + '"') },
+    toString: function () { return Strings.format('%s(%s)', this.constructor.name, this.value) },
 },
 'conversion', {
-	asJS: function (depth) { return '"' + this.value + '"' },
+    asJS: function (depth) { return '"' + this.value + '"' },
 },
 'visiting', {
     accept: function(visitor) {
@@ -118,27 +118,27 @@ users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpr
 
 users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpreter.Cond',
 'testing', {
-	isCond: true,
+    isCond: true,
 },
 'initializing', {
-	initialize: function($super, pos, condExpr, trueExpr, falseExpr) {
-		this.pos = pos;
-		this.condExpr = condExpr;
-		this.trueExpr = trueExpr;
-		this.falseExpr = falseExpr;
-		condExpr.setParent(this);
-		trueExpr.setParent(this);
-		falseExpr.setParent(this);
-	},
+    initialize: function($super, pos, condExpr, trueExpr, falseExpr) {
+        this.pos = pos;
+        this.condExpr = condExpr;
+        this.trueExpr = trueExpr;
+        this.falseExpr = falseExpr;
+        condExpr.setParent(this);
+        trueExpr.setParent(this);
+        falseExpr.setParent(this);
+    },
 },
 'debugging', {
-	printConstruction: function () { return this.printConstructorCall(this.pos, this.condExpr, this.trueExpr, this.falseExpr) },
-	toString: function () { return Strings.format(
+    printConstruction: function () { return this.printConstructorCall(this.pos, this.condExpr, this.trueExpr, this.falseExpr) },
+    toString: function () { return Strings.format(
                 '%s(%s?%s:%s)',
                 this.constructor.name, this.condExpr, this.trueExpr, this.falseExpr) },
 },
 'conversion', {
-	asJS: function (depth) {
+    asJS: function (depth) {
                 return Strings.format(
                     '(%s) ? (%s) : (%s)',
                     this.condExpr.asJS(depth), this.trueExpr.asJS(depth), this.falseExpr.asJS(depth));
@@ -152,10 +152,10 @@ users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpr
 
 users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpreter.If',
 'testing', {
-	isIf: true,
+    isIf: true,
 },
 'initializing', {
-	initialize: function ($super, pos, condExpr, trueExpr, falseExpr) {
+    initialize: function ($super, pos, condExpr, trueExpr, falseExpr) {
                 this.pos = pos;
                 this.condExpr = condExpr;
                 // FIXME actually this could be done with OMeta
@@ -169,13 +169,13 @@ users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpr
             },
 },
 'debugging', {
-	printConstruction: function () { return this.printConstructorCall(this.pos, this.condExpr, this.trueExpr, this.falseExpr) },
-	toString: function () { return Strings.format(
+    printConstruction: function () { return this.printConstructorCall(this.pos, this.condExpr, this.trueExpr, this.falseExpr) },
+    toString: function () { return Strings.format(
                 '%s(%s?%s:%s)',
                 this.constructor.name, this.condExpr, this.trueExpr, this.falseExpr) },
 },
 'conversion', {
-	asJS: function (depth) {
+    asJS: function (depth) {
                 var str = Strings.format(
                     'if (%s) {%s}',
                     this.condExpr.asJS(depth), this.trueExpr.asJS(depth));
@@ -185,13 +185,13 @@ users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpr
             },
 },
 'stepping', {
-	firstStatement: function () {
+    firstStatement: function () {
                 return this.condExpr.firstStatement();
             },
-	nextStatement: function ($super, node) {
+    nextStatement: function ($super, node) {
                 return node === this.condExpr ? this.trueExpr : $super(this);
             },
-	isComposite: function () { return true; },
+    isComposite: function () { return true; },
 },
 'visiting', {
     accept: function(visitor) {
@@ -201,35 +201,35 @@ users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpr
 
 users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpreter.While',
 'testing', {
-	isWhile: true,
+    isWhile: true,
 },
 'initializing', {
-	initialize: function($super, pos, condExpr, body) {
-		this.pos = pos;
-		this.condExpr = condExpr;
-		this.body = body;
-		condExpr.setParent(this);
-		body.setParent(this);
-	},
+    initialize: function($super, pos, condExpr, body) {
+        this.pos = pos;
+        this.condExpr = condExpr;
+        this.body = body;
+        condExpr.setParent(this);
+        body.setParent(this);
+    },
 },
 'debugging', {
-	printConstruction: function () { return this.printConstructorCall(this.pos, this.condExpr, this.body) },
-	toString: function () { return Strings.format(
+    printConstruction: function () { return this.printConstructorCall(this.pos, this.condExpr, this.body) },
+    toString: function () { return Strings.format(
                 '%s(%s?%s)',
                 this.constructor.name, this.condExpr, this.body) },
 },
 'conversion', {
-	asJS: function (depth) {
+    asJS: function (depth) {
                 return Strings.format(
                     'while (%s) {%s}',
                     this.condExpr.asJS(depth), this.body.asJS(depth));
             },
 },
 'stepping', {
-	firstStatement: function () {
+    firstStatement: function () {
                 return this.condExpr.firstStatement();
             },
-	nextStatement: function ($super, node) {
+    nextStatement: function ($super, node) {
                 if (node === this.condExpr) {
                     return this.body;
                 } else if (node === this.body) {
@@ -238,7 +238,7 @@ users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpr
                     return $super(this);
                 }
             },
-	isComposite: function () {
+    isComposite: function () {
                 return true;
             },
 },
@@ -250,35 +250,35 @@ users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpr
 
 users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpreter.DoWhile',
 'testing', {
-	isDoWhile: true,
+    isDoWhile: true,
 },
 'initializing', {
-	initialize: function($super, pos, body, condExpr) {
-		this.pos = pos;
-		this.body = body;
-		this.condExpr = condExpr;
-		body.setParent(this);
-		condExpr.setParent(this);
-	},
+    initialize: function($super, pos, body, condExpr) {
+        this.pos = pos;
+        this.body = body;
+        this.condExpr = condExpr;
+        body.setParent(this);
+        condExpr.setParent(this);
+    },
 },
 'debugging', {
-	printConstruction: function () { return this.printConstructorCall(this.pos, this.body, this.condExpr) },
-	toString: function () { return Strings.format(
+    printConstruction: function () { return this.printConstructorCall(this.pos, this.body, this.condExpr) },
+    toString: function () { return Strings.format(
                 '%s(%s while%s)',
                 this.constructor.name, this.body, this.condExpr) },
 },
 'conversion', {
-	asJS: function (depth) {
+    asJS: function (depth) {
                 return Strings.format(
                     'do {%s} while (%s);',
                     this.body.asJS(depth), this.condExpr.asJS(depth));
             },
 },
 'stepping', {
-	firstStatement: function () {
+    firstStatement: function () {
                 return this.body.firstStatement();
             },
-	nextStatement: function ($super, node) {
+    nextStatement: function ($super, node) {
                 if (node === this.condExpr) {
                     return this.body;
                 } else if (node === this.body) {
@@ -287,7 +287,7 @@ users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpr
                     return $super(this);
                 }
             },
-	isComposite: function () {
+    isComposite: function () {
                 return true;
             },
 },
@@ -299,39 +299,39 @@ users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpr
 
 users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpreter.For',
 'testing', {
-	isFor: true,
+    isFor: true,
 },
 'initializing', {
-	initialize: function($super, pos, init, condExpr, body, upd) {
-		this.pos = pos;
-		this.init = init;
-		this.condExpr = condExpr;
-		this.body = body;
-		this.upd = upd;
-		init.setParent(this);
-		condExpr.setParent(this);
-		body.setParent(this);
-		upd.setParent(this);
-	},
+    initialize: function($super, pos, init, condExpr, body, upd) {
+        this.pos = pos;
+        this.init = init;
+        this.condExpr = condExpr;
+        this.body = body;
+        this.upd = upd;
+        init.setParent(this);
+        condExpr.setParent(this);
+        body.setParent(this);
+        upd.setParent(this);
+    },
 },
 'debugging', {
-	printConstruction: function () { return this.printConstructorCall(this.pos, this.init, this.condExpr, this.body, this.upd) },
-	toString: function () { return Strings.format(
+    printConstruction: function () { return this.printConstructorCall(this.pos, this.init, this.condExpr, this.body, this.upd) },
+    toString: function () { return Strings.format(
                 '%s(%s;%s;%s do %s)',
                 this.constructor.name, this.init, this.condExpr, this.upd, this.body) },
 },
 'conversion', {
-	asJS: function (depth) {
+    asJS: function (depth) {
                 return Strings.format(
                     'for (%s; %s; %s) {%s}',
                     this.init.asJS(depth), this.condExpr.asJS(depth), this.upd.asJS(depth), this.body.asJS(depth));
             },
 },
 'stepping', {
-	firstStatement: function () {
+    firstStatement: function () {
                 return this.init.firstStatement();
             },
-	nextStatement: function ($super, node) {
+    nextStatement: function ($super, node) {
                 if (node === this.init || node === this.upd) {
                     return this.condExpr;
                 } else if (node === this.condExpr) {
@@ -342,7 +342,7 @@ users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpr
                     return $super(this);
                 }
             },
-	isComposite: function () {
+    isComposite: function () {
                 return true;
             },
 },
@@ -354,29 +354,29 @@ users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpr
 
 users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpreter.ForIn',
 'testing', {
-	isForIn: true,
+    isForIn: true,
 },
 'initializing', {
-	initialize: function($super, pos, name, obj, body) {
-		this.pos = pos;
-		this.name = name;
-		this.obj = obj;
-		this.body = body;
-		name.setParent(this);
-		obj.setParent(this);
-		body.setParent(this);
-	},
+    initialize: function($super, pos, name, obj, body) {
+        this.pos = pos;
+        this.name = name;
+        this.obj = obj;
+        this.body = body;
+        name.setParent(this);
+        obj.setParent(this);
+        body.setParent(this);
+    },
 },
 'debugging', {
-	printConstruction: function () { return this.printConstructorCall(this.pos, this.name, this.obj, this.body) },
-	toString: function () {
+    printConstruction: function () { return this.printConstructorCall(this.pos, this.name, this.obj, this.body) },
+    toString: function () {
                 return Strings.format(
                     '%s(%s in %s do %s)',
                     this.constructor.name, this.name, this.obj, this.body);
             },
 },
 'conversion', {
-	asJS: function (depth) {
+    asJS: function (depth) {
                 return Strings.format(
                     'for (%s in %s) {%s}',
                     this.name.asJS(depth), this.obj.asJS(depth), this.body.asJS(depth));
@@ -390,25 +390,25 @@ users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpr
 
 users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpreter.Set',
 'testing', {
-	isSet: true,
+    isSet: true,
 },
 'initializing', {
-	initialize: function($super, pos, left, right) {
-		this.pos = pos;
-		this.left = left;
-		this.right = right;
-		left.setParent(this);
-		right.setParent(this);
-	},
+    initialize: function($super, pos, left, right) {
+        this.pos = pos;
+        this.left = left;
+        this.right = right;
+        left.setParent(this);
+        right.setParent(this);
+    },
 },
 'debugging', {
-	printConstruction: function () { return this.printConstructorCall(this.pos, this.left, this.right) },
-	toString: function () { return Strings.format(
+    printConstruction: function () { return this.printConstructorCall(this.pos, this.left, this.right) },
+    toString: function () { return Strings.format(
                 '%s(%s = %s)',
                 this.constructor.name, this.left, this.right) },
 },
 'conversion', {
-	asJS: function (depth) { return this.left.asJS(depth) + ' = ' + this.right.asJS(depth) },
+    asJS: function (depth) { return this.left.asJS(depth) + ' = ' + this.right.asJS(depth) },
 },
 'visiting', {
     accept: function(visitor) {
@@ -418,26 +418,26 @@ users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpr
 
 users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpreter.ModifyingSet',
 'testing', {
-	isModifyingSet: true,
+    isModifyingSet: true,
 },
 'initializing', {
-	initialize: function($super, pos, left, name, right) {
-		this.pos = pos;
-		this.left = left;
-		this.name = name;
-		this.right = right;
-		left.setParent(this);
-		right.setParent(this);
-	},
+    initialize: function($super, pos, left, name, right) {
+        this.pos = pos;
+        this.left = left;
+        this.name = name;
+        this.right = right;
+        left.setParent(this);
+        right.setParent(this);
+    },
 },
 'debugging', {
-	printConstruction: function () { return this.printConstructorCall(this.pos, this.left, '"' + this.name + '"', this.right) },
-	toString: function () { return Strings.format(
+    printConstruction: function () { return this.printConstructorCall(this.pos, this.left, '"' + this.name + '"', this.right) },
+    toString: function () { return Strings.format(
                 '%s(%s %s %s)',
                 this.constructor.name, this.left, this.name, this.right) },
 },
 'conversion', {
-	asJS: function (depth) { return this.left.asJS(depth) + ' ' + this.name + '= ' + this.right.asJS(depth) },
+    asJS: function (depth) { return this.left.asJS(depth) + ' ' + this.name + '= ' + this.right.asJS(depth) },
 },
 'visiting', {
     accept: function(visitor) {
@@ -447,26 +447,26 @@ users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpr
 
 users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpreter.BinaryOp',
 'testing', {
-	isBinaryOp: true,
+    isBinaryOp: true,
 },
 'initializing', {
-	initialize: function($super, pos, name, left, right) {
-		this.pos = pos;
-		this.name = name;
-		this.left = left;
-		this.right = right;
-		left.setParent(this);
-		right.setParent(this);
-	},
+    initialize: function($super, pos, name, left, right) {
+        this.pos = pos;
+        this.name = name;
+        this.left = left;
+        this.right = right;
+        left.setParent(this);
+        right.setParent(this);
+    },
 },
 'debugging', {
-	printConstruction: function () { return this.printConstructorCall(this.pos, '"' + this.name + '"', this.left, this.right) },
-	toString: function () { return Strings.format(
+    printConstruction: function () { return this.printConstructorCall(this.pos, '"' + this.name + '"', this.left, this.right) },
+    toString: function () { return Strings.format(
                 '%s(%s %s %s)',
                 this.constructor.name, this.left, this.name, this.right) },
 },
 'conversion', {
-	asJS: function (depth) { return '(' + this.left.asJS(depth) + ') ' + this.name + ' (' + this.right.asJS(depth) + ')' },
+    asJS: function (depth) { return '(' + this.left.asJS(depth) + ') ' + this.name + ' (' + this.right.asJS(depth) + ')' },
 },
 'visiting', {
     accept: function(visitor) {
@@ -476,24 +476,24 @@ users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpr
 
 users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpreter.UnaryOp',
 'testing', {
-	isUnaryOp: true,
+    isUnaryOp: true,
 },
 'initializing', {
-	initialize: function($super, pos, name, expr) {
-		this.pos = pos;
-		this.name = name;
-		this.expr = expr;
-		expr.setParent(this);
-	},
+    initialize: function($super, pos, name, expr) {
+        this.pos = pos;
+        this.name = name;
+        this.expr = expr;
+        expr.setParent(this);
+    },
 },
 'debugging', {
-	printConstruction: function () { return this.printConstructorCall(this.pos, '"' + this.name + '"', this.expr) },
-	toString: function () { return Strings.format(
+    printConstruction: function () { return this.printConstructorCall(this.pos, '"' + this.name + '"', this.expr) },
+    toString: function () { return Strings.format(
                 '%s(%s%s)',
                 this.constructor.name, this.name, this.expr) },
 },
 'conversion', {
-	asJS: function (depth) { return '(' + this.name + this.expr.asJS(depth) + ')'},
+    asJS: function (depth) { return '(' + this.name + this.expr.asJS(depth) + ')'},
 },
 'visiting', {
     accept: function(visitor) {
@@ -503,24 +503,24 @@ users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpr
 
 users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpreter.PreOp',
 'testing', {
-	isPreOp: true,
+    isPreOp: true,
 },
 'initializing', {
-	initialize: function($super, pos, name, expr) {
-		this.pos = pos;
-		this.name = name;
-		this.expr = expr;
-		expr.setParent(this);
-	},
+    initialize: function($super, pos, name, expr) {
+        this.pos = pos;
+        this.name = name;
+        this.expr = expr;
+        expr.setParent(this);
+    },
 },
 'debugging', {
-	printConstruction: function () { return this.printConstructorCall(this.pos, '"' + this.name+'"', this.expr) },
-	toString: function () { return Strings.format(
+    printConstruction: function () { return this.printConstructorCall(this.pos, '"' + this.name+'"', this.expr) },
+    toString: function () { return Strings.format(
                 '%s(%s%s)',
                 this.constructor.name, this.name, this.expr) },
 },
 'conversion', {
-	asJS: function (depth) { return '(' + this.name + this.expr.asJS(depth) + ')' },
+    asJS: function (depth) { return '(' + this.name + this.expr.asJS(depth) + ')' },
 },
 'visiting', {
     accept: function(visitor) {
@@ -530,24 +530,24 @@ users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpr
 
 users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpreter.PostOp',
 'testing', {
-	isPostOp: true,
+    isPostOp: true,
 },
 'initializing', {
-	initialize: function($super, pos, name, expr) {
-		this.pos = pos;
-		this.name = name;
-		this.expr = expr;
-		expr.setParent(this);
-	},
+    initialize: function($super, pos, name, expr) {
+        this.pos = pos;
+        this.name = name;
+        this.expr = expr;
+        expr.setParent(this);
+    },
 },
 'debugging', {
-	printConstruction: function () { return this.printConstructorCall(this.pos, '"'+this.name+'"', this.expr) },
-	toString: function () { return Strings.format(
+    printConstruction: function () { return this.printConstructorCall(this.pos, '"'+this.name+'"', this.expr) },
+    toString: function () { return Strings.format(
                 '%s(%s%s)',
                 this.constructor.name, this.expr, this.name) },
 },
 'conversion', {
-	asJS: function (depth) { return '(' + this.expr.asJS(depth) + this.name + ')'},
+    asJS: function (depth) { return '(' + this.expr.asJS(depth) + this.name + ')'},
 },
 'visiting', {
     accept: function(visitor) {
@@ -557,20 +557,20 @@ users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpr
 
 users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpreter.This',
 'testing', {
-	isThis: true,
+    isThis: true,
 },
 'initializing', {
-	initialize: function($super, pos) {
-		this.pos = pos;
+    initialize: function($super, pos) {
+        this.pos = pos;
 
-	},
+    },
 },
 'debugging', {
-	printConstruction: function () { return this.printConstructorCall(this.pos) },
-	toString: function () { return this.constructor.name },
+    printConstruction: function () { return this.printConstructorCall(this.pos) },
+    toString: function () { return this.constructor.name },
 },
 'conversion', {
-	asJS: function (depth) { return 'this' },
+    asJS: function (depth) { return 'this' },
 },
 'visiting', {
     accept: function(visitor) {
@@ -580,23 +580,23 @@ users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpr
 
 users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpreter.Variable',
 'testing', {
-	isVariable: true,
+    isVariable: true,
 },
 'initializing', {
-	initialize: function($super, pos, name) {
-		this.pos = pos;
-		this.name = name;
+    initialize: function($super, pos, name) {
+        this.pos = pos;
+        this.name = name;
 
-	},
+    },
 },
 'debugging', {
-	printConstruction: function () { return this.printConstructorCall(this.pos, '"'+this.name+'"') },
-	toString: function () { return Strings.format(
+    printConstruction: function () { return this.printConstructorCall(this.pos, '"'+this.name+'"') },
+    toString: function () { return Strings.format(
                 '%s(%s)',
                 this.constructor.name, this.name) },
 },
 'conversion', {
-	asJS: function (depth) { return this.name },
+    asJS: function (depth) { return this.name },
 },
 'visiting', {
     accept: function(visitor) {
@@ -606,25 +606,25 @@ users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpr
 
 users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpreter.GetSlot',
 'testing', {
-	isGetSlot: true,
+    isGetSlot: true,
 },
 'initializing', {
-	initialize: function($super, pos, slotName, obj) {
-		this.pos = pos;
-		this.slotName = slotName;
-		this.obj = obj;
-		slotName.setParent(this);
-		obj.setParent(this);
-	},
+    initialize: function($super, pos, slotName, obj) {
+        this.pos = pos;
+        this.slotName = slotName;
+        this.obj = obj;
+        slotName.setParent(this);
+        obj.setParent(this);
+    },
 },
 'debugging', {
-	printConstruction: function () { return this.printConstructorCall(this.pos, this.slotName, this.obj) },
-	toString: function () { return Strings.format(
+    printConstruction: function () { return this.printConstructorCall(this.pos, this.slotName, this.obj) },
+    toString: function () { return Strings.format(
                 '%s(%s[%s])',
                 this.constructor.name, this.obj, this.slotName) },
 },
 'conversion', {
-	asJS: function (depth) {
+    asJS: function (depth) {
                 var objJS = this.obj.asJS(depth);
                 if (this.obj.isFunction) objJS = '(' + objJS + ')';
                 return objJS + '[' + this.slotName.asJS(depth) + ']';
@@ -638,20 +638,20 @@ users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpr
 
 users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpreter.Break',
 'testing', {
-	isBreak: true,
+    isBreak: true,
 },
 'initializing', {
-	initialize: function ($super, pos, label) {
-            		this.pos = pos;
-            		this.label = label || new users.timfelgentreff.jsinterpreter.Label([pos[1], pos[1]], '');
-            		this.label.setParent(this);
-          	},
+    initialize: function ($super, pos, label) {
+                    this.pos = pos;
+                    this.label = label || new users.timfelgentreff.jsinterpreter.Label([pos[1], pos[1]], '');
+                    this.label.setParent(this);
+              },
 },
 'debugging', {
-	printConstruction: function () { return this.printConstructorCall(this.pos, this.label) },
+    printConstruction: function () { return this.printConstructorCall(this.pos, this.label) },
 },
 'conversion', {
-	asJS: function (depth) { return 'break' + this.label.asJS(); },
+    asJS: function (depth) { return 'break' + this.label.asJS(); },
 },
 'visiting', {
     accept: function(visitor) {
@@ -661,19 +661,19 @@ users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpr
 
 users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpreter.Debugger',
 'testing', {
-	isDebugger: true,
+    isDebugger: true,
 },
 'initializing', {
-	initialize: function($super, pos) {
-		this.pos = pos;
+    initialize: function($super, pos) {
+        this.pos = pos;
 
-	},
+    },
 },
 'debugging', {
-	printConstruction: function () { return this.printConstructorCall(this.pos) },
+    printConstruction: function () { return this.printConstructorCall(this.pos) },
 },
 'conversion', {
-	asJS: function (depth) { return 'debugger' },
+    asJS: function (depth) { return 'debugger' },
 },
 'visiting', {
     accept: function(visitor) {
@@ -683,20 +683,20 @@ users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpr
 
 users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpreter.Continue',
 'testing', {
-	isContinue: true,
+    isContinue: true,
 },
 'initializing', {
-	initialize: function ($super, pos, label) {
-            		this.pos = pos;
-            		this.label = label || new users.timfelgentreff.jsinterpreter.Label([pos[1], pos[1]], '');
-            		this.label.setParent(this);
-          	},
+    initialize: function ($super, pos, label) {
+                    this.pos = pos;
+                    this.label = label || new users.timfelgentreff.jsinterpreter.Label([pos[1], pos[1]], '');
+                    this.label.setParent(this);
+              },
 },
 'debugging', {
-	printConstruction: function () { return this.printConstructorCall(this.pos, this.label) },
+    printConstruction: function () { return this.printConstructorCall(this.pos, this.label) },
 },
 'conversion', {
-	asJS: function (depth) { return 'continue' + this.label.asJS(); },
+    asJS: function (depth) { return 'continue' + this.label.asJS(); },
 },
 'visiting', {
     accept: function(visitor) {
@@ -706,23 +706,23 @@ users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpr
 
 users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpreter.ArrayLiteral',
 'testing', {
-	isArrayLiteral: true,
+    isArrayLiteral: true,
 },
 'initializing', {
-	initialize: function($super, pos, elements) {
-		this.pos = pos;
-		this.elements = elements;
-		elements.forEach(function(node) { node.setParent(this) }, this);
-	},
+    initialize: function($super, pos, elements) {
+        this.pos = pos;
+        this.elements = elements;
+        elements.forEach(function(node) { node.setParent(this) }, this);
+    },
 },
 'debugging', {
-	printConstruction: function () { return this.printConstructorCall(this.pos, this.elements) },
-	toString: function () { return Strings.format(
+    printConstruction: function () { return this.printConstructorCall(this.pos, this.elements) },
+    toString: function () { return Strings.format(
                 '%s(%s)',
                 this.constructor.name, this.elements.join(',')) },
 },
 'conversion', {
-	asJS: function (depth) { return '[' + this.elements.invoke('asJS').join(',') + ']' },
+    asJS: function (depth) { return '[' + this.elements.invoke('asJS').join(',') + ']' },
 },
 'visiting', {
     accept: function(visitor) {
@@ -732,23 +732,23 @@ users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpr
 
 users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpreter.Return',
 'testing', {
-	isReturn: true,
+    isReturn: true,
 },
 'initializing', {
-	initialize: function($super, pos, expr) {
-		this.pos = pos;
-		this.expr = expr;
-		expr.setParent(this);
-	},
+    initialize: function($super, pos, expr) {
+        this.pos = pos;
+        this.expr = expr;
+        expr.setParent(this);
+    },
 },
 'debugging', {
-	printConstruction: function () { return this.printConstructorCall(this.pos, this.expr) },
-	toString: function () { return Strings.format(
+    printConstruction: function () { return this.printConstructorCall(this.pos, this.expr) },
+    toString: function () { return Strings.format(
                 '%s(%s)',
                 this.constructor.name, this.expr) },
 },
 'conversion', {
-	asJS: function (depth) { return 'return ' + this.expr.asJS(depth) },
+    asJS: function (depth) { return 'return ' + this.expr.asJS(depth) },
 },
 'visiting', {
     accept: function(visitor) {
@@ -758,25 +758,25 @@ users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpr
 
 users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpreter.With',
 'testing', {
-	isWith: true,
+    isWith: true,
 },
 'initializing', {
-	initialize: function($super, pos, obj, body) {
-		this.pos = pos;
-		this.obj = obj;
-		this.body = body;
-		obj.setParent(this);
-		body.setParent(this);
-	},
+    initialize: function($super, pos, obj, body) {
+        this.pos = pos;
+        this.obj = obj;
+        this.body = body;
+        obj.setParent(this);
+        body.setParent(this);
+    },
 },
 'debugging', {
-	printConstruction: function () { return this.printConstructorCall(this.pos, this.obj, this.body) },
-	toString: function () { return Strings.format(
+    printConstruction: function () { return this.printConstructorCall(this.pos, this.obj, this.body) },
+    toString: function () { return Strings.format(
                 '%s(%s %s)',
                 this.constructor.name, this.obj, this.body) },
 },
 'conversion', {
-	asJS: function (depth) { return 'with (' + this.obj.asJS(depth) + ') {' + this.body.asJS(depth) + '}' },
+    asJS: function (depth) { return 'with (' + this.obj.asJS(depth) + ') {' + this.body.asJS(depth) + '}' },
 },
 'visiting', {
     accept: function(visitor) {
@@ -786,30 +786,30 @@ users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpr
 
 users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpreter.Send',
 'testing', {
-	isSend: true,
+    isSend: true,
 },
 'initializing', {
-	initialize: function($super, pos, property, recv, args) {
-		this.pos = pos;
-		this.property = property;
-		this.recv = recv;
-		this.args = args;
-		args.forEach(function(node) { node.setParent(this) }, this);
-		property.setParent(this);
-		recv.setParent(this);
-	},
+    initialize: function($super, pos, property, recv, args) {
+        this.pos = pos;
+        this.property = property;
+        this.recv = recv;
+        this.args = args;
+        args.forEach(function(node) { node.setParent(this) }, this);
+        property.setParent(this);
+        recv.setParent(this);
+    },
 },
 'debugging', {
-	printConstruction: function () {
+    printConstruction: function () {
                 return this.printConstructorCall(this.pos, this.property, this.recv, this.args)
             },
-	toString: function () {
+    toString: function () {
                 return Strings.format('%s(%s[%s](%s))',
                     this.constructor.name, this.recv, this.property, this.args.join(','))
             },
 },
 'conversion', {
-	asJS: function (depth) {
+    asJS: function (depth) {
                 var recvJS = this.recv.asJS(depth);
                 if (this.recv.isFunction) recvJS = '(' + recvJS + ')';
                 return Strings.format(
@@ -818,7 +818,7 @@ users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpr
             },
 },
 'accessing', {
-	getName: function () { return this.property },
+    getName: function () { return this.property },
 },
 'visiting', {
     accept: function(visitor) {
@@ -828,31 +828,31 @@ users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpr
 
 users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpreter.Call',
 'testing', {
-	isCall: true,
+    isCall: true,
 },
 'initializing', {
-	initialize: function($super, pos, fn, args) {
-		this.pos = pos;
-		this.fn = fn;
-		this.args = args;
-		args.forEach(function(node) { node.setParent(this) }, this);
-		fn.setParent(this);
-	},
+    initialize: function($super, pos, fn, args) {
+        this.pos = pos;
+        this.fn = fn;
+        this.args = args;
+        args.forEach(function(node) { node.setParent(this) }, this);
+        fn.setParent(this);
+    },
 },
 'debugging', {
-	printConstruction: function () { return this.printConstructorCall(this.pos, this.fn, this.args) },
-	toString: function () { return Strings.format(
+    printConstruction: function () { return this.printConstructorCall(this.pos, this.fn, this.args) },
+    toString: function () { return Strings.format(
                 '%s(%s(%s))',
                 this.constructor.name, this.fn, this.args.join(',')) },
 },
 'conversion', {
-	asJS: function (depth) {
+    asJS: function (depth) {
                 return Strings.format('%s(%s)',
                                       this.fn.asJS(depth), this.args.invoke('asJS').join(','));
             },
 },
 'accessing', {
-	getName: function () { return this.fn.name },
+    getName: function () { return this.fn.name },
 },
 'visiting', {
     accept: function(visitor) {
@@ -862,23 +862,23 @@ users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpr
 
 users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpreter.New',
 'testing', {
-	isNew: true,
+    isNew: true,
 },
 'initializing', {
-	initialize: function($super, pos, clsExpr) {
-		this.pos = pos;
-		this.clsExpr = clsExpr;
-		clsExpr.setParent(this);
-	},
+    initialize: function($super, pos, clsExpr) {
+        this.pos = pos;
+        this.clsExpr = clsExpr;
+        clsExpr.setParent(this);
+    },
 },
 'debugging', {
-	printConstruction: function () { return this.printConstructorCall(this.pos, this.clsExpr) },
-	toString: function () { return Strings.format(
+    printConstruction: function () { return this.printConstructorCall(this.pos, this.clsExpr) },
+    toString: function () { return Strings.format(
                 '%s(%s)',
                 this.constructor.name, this.clsExpr) },
 },
 'conversion', {
-	asJS: function (depth) {
+    asJS: function (depth) {
                 return 'new ' + this.clsExpr.asJS(depth);
             },
 },
@@ -890,24 +890,24 @@ users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpr
 
 users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpreter.VarDeclaration',
 'testing', {
-	isVarDeclaration: true,
+    isVarDeclaration: true,
 },
 'initializing', {
-	initialize: function($super, pos, name, val) {
-		this.pos = pos;
-		this.name = name;
-		this.val = val;
-		val.setParent(this);
-	},
+    initialize: function($super, pos, name, val) {
+        this.pos = pos;
+        this.name = name;
+        this.val = val;
+        val.setParent(this);
+    },
 },
 'debugging', {
-	printConstruction: function () { return this.printConstructorCall(this.pos, '"'+this.name+'"', this.val) },
-	toString: function () { return Strings.format(
+    printConstruction: function () { return this.printConstructorCall(this.pos, '"'+this.name+'"', this.val) },
+    toString: function () { return Strings.format(
                 '%s(%s = %s)',
                 this.constructor.name, this.name, this.val) },
 },
 'conversion', {
-	asJS: function (depth) {
+    asJS: function (depth) {
                 return Strings.format('var %s = %s', this.name, this.val.asJS(depth));
             },
 },
@@ -919,25 +919,25 @@ users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpr
 
 users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpreter.Throw',
 'testing', {
-	isThrow: true,
+    isThrow: true,
 },
 'initializing', {
-	initialize: function($super, pos, expr) {
-		this.pos = pos;
-		this.expr = expr;
-		expr.setParent(this);
-	},
+    initialize: function($super, pos, expr) {
+        this.pos = pos;
+        this.expr = expr;
+        expr.setParent(this);
+    },
 },
 'debugging', {
-	printConstruction: function () { return this.printConstructorCall(this.pos, this.expr) },
-	toString: function () {
+    printConstruction: function () { return this.printConstructorCall(this.pos, this.expr) },
+    toString: function () {
                 return Strings.format(
                     '%s(%s)',
                     this.constructor.name, this.expr)
             },
 },
 'conversion', {
-	asJS: function (depth) { return 'throw ' + this.expr.asJS(depth) },
+    asJS: function (depth) { return 'throw ' + this.expr.asJS(depth) },
 },
 'visiting', {
     accept: function(visitor) {
@@ -947,31 +947,31 @@ users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpr
 
 users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpreter.TryCatchFinally',
 'testing', {
-	isTryCatchFinally: true,
+    isTryCatchFinally: true,
 },
 'initializing', {
-	initialize: function($super, pos, trySeq, err, catchSeq, finallySeq) {
-		this.pos = pos;
-		this.trySeq = trySeq;
-		this.err = err;
-		this.catchSeq = catchSeq;
-		this.finallySeq = finallySeq;
-		trySeq.setParent(this);
-		err.setParent(this);
-		catchSeq.setParent(this);
-		finallySeq.setParent(this);
-	},
+    initialize: function($super, pos, trySeq, err, catchSeq, finallySeq) {
+        this.pos = pos;
+        this.trySeq = trySeq;
+        this.err = err;
+        this.catchSeq = catchSeq;
+        this.finallySeq = finallySeq;
+        trySeq.setParent(this);
+        err.setParent(this);
+        catchSeq.setParent(this);
+        finallySeq.setParent(this);
+    },
 },
 'debugging', {
-	printConstruction: function () { return this.printConstructorCall(this.pos, this.trySeq, '"'+this.err.name+'"', this.catchSeq, this.finallySeq) },
-	toString: function () {
+    printConstruction: function () { return this.printConstructorCall(this.pos, this.trySeq, '"'+this.err.name+'"', this.catchSeq, this.finallySeq) },
+    toString: function () {
                 return Strings.format(
                     '%s(%s %s %s)',
                     this.constructor.name, this.trySeq, this.catchSeq, this.finallySeq)
             },
 },
 'conversion', {
-	asJS: function (depth) {
+    asJS: function (depth) {
                 var baseIndent = this.indent(depth-1),
                     indent = this.indent(depth),
                 str = 'try {\n' + indent + this.trySeq.asJS(depth) + '\n' + baseIndent + '}';
@@ -991,50 +991,50 @@ users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpr
 
 users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpreter.Function',
 'testing', {
-	isFunction: true,
+    isFunction: true,
 },
 'initializing', {
-	initialize: function($super, pos, body, args) {
-		this.pos = pos;
-		this.body = body;
-		this.args = args;
-		args.forEach(function(node) { node.setParent(this) }, this);
-		body.setParent(this);
-	},
+    initialize: function($super, pos, body, args) {
+        this.pos = pos;
+        this.body = body;
+        this.args = args;
+        args.forEach(function(node) { node.setParent(this) }, this);
+        body.setParent(this);
+    },
 },
 'debugging', {
-	printConstruction: function () { return this.printConstructorCall(this.pos, this.body, this.args.collect(function(ea) { return '"' + ea.name + '"' })) },
-	toString: function () {
+    printConstruction: function () { return this.printConstructorCall(this.pos, this.body, this.args.collect(function(ea) { return '"' + ea.name + '"' })) },
+    toString: function () {
                 return Strings.format(
                     '%s(function %s(%s) %s)',
                     this.constructor.name, this.name(), this.argNames().join(','), this.body)
             },
 },
 'conversion', {
-	asJS: function (depth) {
+    asJS: function (depth) {
                 return Strings.format('function%s(%s) {\n%s\n}',
                                       this.name() ? ' ' + this.name() : '', this.argNames().join(','),
                                       this.indent(depth+1) + this.body.asJS(depth+1));
             },
 },
 'accessing', {
-	name: function () {
+    name: function () {
                 if (this._parent && this._parent.isVarDeclaration) {
                     return this._parent.name;
                 }
                 return undefined;
             },
-	parentFunction: function () { return this },
-	argNames: function () { return this.args.collect(function(a){ return a.name }); },
-	statements: function () { return this.body.children },
+    parentFunction: function () { return this },
+    argNames: function () { return this.args.collect(function(a){ return a.name }); },
+    statements: function () { return this.body.children },
 },
 'stepping', {
-	firstStatement: function () { return this.body.firstStatement(); },
-	nextStatement: function (node) { return null; },
-	isComposite: function () { return true; },
+    firstStatement: function () { return this.body.firstStatement(); },
+    nextStatement: function (node) { return null; },
+    isComposite: function () { return true; },
 },
 'evaluation', {
-	eval: function () {
+    eval: function () {
                 return new Function(this.argNames().join(","), this.body.asJS());
             },
 },
@@ -1046,25 +1046,25 @@ users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpr
 
 users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpreter.ObjectLiteral',
 'testing', {
-	isObjectLiteral: true,
+    isObjectLiteral: true,
 },
 'initializing', {
-	initialize: function($super, pos, properties) {
-		this.pos = pos;
-		this.properties = properties;
-		properties.forEach(function(node) { node.setParent(this) }, this);
-	},
+    initialize: function($super, pos, properties) {
+        this.pos = pos;
+        this.properties = properties;
+        properties.forEach(function(node) { node.setParent(this) }, this);
+    },
 },
 'debugging', {
-	printConstruction: function () { return this.printConstructorCall(this.pos, this.properties) },
-	toString: function () {
+    printConstruction: function () { return this.printConstructorCall(this.pos, this.properties) },
+    toString: function () {
                 return Strings.format(
                     '%s({%s})',
                     this.constructor.name, this.properties.join(','))
             },
 },
 'conversion', {
-	asJS: function (depth) {
+    asJS: function (depth) {
                 return '{' + this.properties.invoke('asJS').join(',') + '}';
             },
 },
@@ -1076,25 +1076,25 @@ users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpr
 
 users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpreter.ObjProperty',
 'testing', {
-	isObjProperty: true,
+    isObjProperty: true,
 },
 'initializing', {
-	initialize: function($super, pos, name, property) {
-		this.pos = pos;
-		this.name = name;
-		this.property = property;
-		property.setParent(this);
-	},
+    initialize: function($super, pos, name, property) {
+        this.pos = pos;
+        this.name = name;
+        this.property = property;
+        property.setParent(this);
+    },
 },
 'debugging', {
-	printConstruction: function () { return this.printConstructorCall(this.pos, '"'+this.name+'"', this.property) },
-	toString: function () {
+    printConstruction: function () { return this.printConstructorCall(this.pos, '"'+this.name+'"', this.property) },
+    toString: function () {
           return Strings.format(
               '%s(%s: %s)',
               this.constructor.name, this.name, this.property) },
 },
 'conversion', {
-	asJS: function (depth) {
+    asJS: function (depth) {
                 return Strings.format('"%s": %s', this.name, this.property.asJS(depth));
             },
 },
@@ -1106,25 +1106,25 @@ users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpr
 
 users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpreter.ObjPropertyGet',
 'testing', {
-	isObjPropertyGet: true,
+    isObjPropertyGet: true,
 },
 'initializing', {
-	initialize: function($super, pos, name, body) {
-		this.pos = pos;
-		this.name = name;
-		this.body = body;
-		body.setParent(this);
-	},
+    initialize: function($super, pos, name, body) {
+        this.pos = pos;
+        this.name = name;
+        this.body = body;
+        body.setParent(this);
+    },
 },
 'debugging', {
-	printConstruction: function () { return this.printConstructorCall(this.pos, '"'+this.name+'"', this.body) },
-	toString: function () {
+    printConstruction: function () { return this.printConstructorCall(this.pos, '"'+this.name+'"', this.body) },
+    toString: function () {
           return Strings.format(
               '%s(%s() { %s })',
               this.constructor.name, this.name, this.body) },
 },
 'conversion', {
-	asJS: function (depth) {
+    asJS: function (depth) {
                 return Strings.format('get "%s"() { %s }', this.name, this.body.asJS(depth));
             },
 },
@@ -1136,26 +1136,26 @@ users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpr
 
 users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpreter.ObjPropertySet',
 'testing', {
-	isObjPropertySet: true,
+    isObjPropertySet: true,
 },
 'initializing', {
-	initialize: function($super, pos, name, body, arg) {
-		this.pos = pos;
-		this.name = name;
-		this.body = body;
-		this.arg = arg;
-		body.setParent(this);
-	},
+    initialize: function($super, pos, name, body, arg) {
+        this.pos = pos;
+        this.name = name;
+        this.body = body;
+        this.arg = arg;
+        body.setParent(this);
+    },
 },
 'debugging', {
-	printConstruction: function () { return this.printConstructorCall(this.pos, '"'+this.name+'"', this.body, this.arg) },
-	toString: function () {
+    printConstruction: function () { return this.printConstructorCall(this.pos, '"'+this.name+'"', this.body, this.arg) },
+    toString: function () {
           return Strings.format(
               '%s(%s(%s) { %s })',
               this.constructor.name, this.name, this.arg, this.body) },
 },
 'conversion', {
-	asJS: function (depth) {
+    asJS: function (depth) {
                 return Strings.format('set "%s"(%s) { %s }', this.name, this.arg, this.body.asJS(depth));
             },
 },
@@ -1167,24 +1167,24 @@ users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpr
 
 users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpreter.Switch',
 'testing', {
-	isSwitch: true,
+    isSwitch: true,
 },
 'initializing', {
-	initialize: function($super, pos, expr, cases) {
-		this.pos = pos;
-		this.expr = expr;
-		this.cases = cases;
-		cases.forEach(function(node) { node.setParent(this) }, this);
-		expr.setParent(this);
-	},
+    initialize: function($super, pos, expr, cases) {
+        this.pos = pos;
+        this.expr = expr;
+        this.cases = cases;
+        cases.forEach(function(node) { node.setParent(this) }, this);
+        expr.setParent(this);
+    },
 },
 'debugging', {
-	printConstruction: function () { return this.printConstructorCall(this.pos, this.expr, this.cases) },
-	toString: function () { return Strings.format('%s(%s %s)',
+    printConstruction: function () { return this.printConstructorCall(this.pos, this.expr, this.cases) },
+    toString: function () { return Strings.format('%s(%s %s)',
                                                          this.constructor.name, this.expr, this.cases.join('\n')) },
 },
 'conversion', {
-	asJS: function (depth) {
+    asJS: function (depth) {
                 return Strings.format('switch (%s) {%s}',
                                       this.expr.asJS(depth), this.cases.invoke('asJS').join('\n'));
             },
@@ -1197,26 +1197,26 @@ users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpr
 
 users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpreter.Case',
 'testing', {
-	isCase: true,
+    isCase: true,
 },
 'initializing', {
-	initialize: function($super, pos, condExpr, thenExpr) {
-		this.pos = pos;
-		this.condExpr = condExpr;
-		this.thenExpr = thenExpr;
-		condExpr.setParent(this);
-		thenExpr.setParent(this);
-	},
+    initialize: function($super, pos, condExpr, thenExpr) {
+        this.pos = pos;
+        this.condExpr = condExpr;
+        this.thenExpr = thenExpr;
+        condExpr.setParent(this);
+        thenExpr.setParent(this);
+    },
 },
 'debugging', {
-	printConstruction: function () { return this.printConstructorCall(this.pos, this.condExpr, this.thenExpr) },
-	toString: function () {
+    printConstruction: function () { return this.printConstructorCall(this.pos, this.condExpr, this.thenExpr) },
+    toString: function () {
                 return Strings.format(
                     '%s(%s: %s)',
                     this.constructor.name, this.condExpr, this.thenExpr) },
 },
 'conversion', {
-	asJS: function (depth) {
+    asJS: function (depth) {
                 return 'case ' + this.condExpr.asJS(depth) + ': ' + this.thenExpr.asJS(depth);
             },
 },
@@ -1228,23 +1228,23 @@ users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpr
 
 users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpreter.Default',
 'testing', {
-	isDefault: true,
+    isDefault: true,
 },
 'initializing', {
-	initialize: function($super, pos, defaultExpr) {
-		this.pos = pos;
-		this.defaultExpr = defaultExpr;
-		defaultExpr.setParent(this);
-	},
+    initialize: function($super, pos, defaultExpr) {
+        this.pos = pos;
+        this.defaultExpr = defaultExpr;
+        defaultExpr.setParent(this);
+    },
 },
 'debugging', {
-	printConstruction: function () { return this.printConstructorCall(this.pos, this.defaultExpr) },
-	toString: function () { return Strings.format(
+    printConstruction: function () { return this.printConstructorCall(this.pos, this.defaultExpr) },
+    toString: function () { return Strings.format(
                 '%s(default: %s)',
                 this.constructor.name,  this.defaultExpr) },
 },
 'conversion', {
-	asJS: function (depth) { return 'default: ' + this.defaultExpr.asJS(depth) },
+    asJS: function (depth) { return 'default: ' + this.defaultExpr.asJS(depth) },
 },
 'visiting', {
     accept: function(visitor) {
@@ -1254,22 +1254,22 @@ users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpr
 
 users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpreter.Regex',
 'testing', {
-	isRegex: true,
+    isRegex: true,
 },
 'initializing', {
-	initialize: function($super, pos, exprString, flags) {
-		this.pos = pos;
-		this.exprString = exprString;
-		this.flags = flags;
+    initialize: function($super, pos, exprString, flags) {
+        this.pos = pos;
+        this.exprString = exprString;
+        this.flags = flags;
 
-	},
+    },
 },
 'debugging', {
-	printConstruction: function () { return this.printConstructorCall(this.pos, this.exprString, this.flags) },
-	toString: function () { return Strings.format('(/%s/%s)', this.exprString, this.flags) },
+    printConstruction: function () { return this.printConstructorCall(this.pos, this.exprString, this.flags) },
+    toString: function () { return Strings.format('(/%s/%s)', this.exprString, this.flags) },
 },
 'conversion', {
-	asJS: function (depth) { return '/' + this.exprString + '/' + this.flags},
+    asJS: function (depth) { return '/' + this.exprString + '/' + this.flags},
 },
 'visiting', {
     accept: function(visitor) {
@@ -1279,21 +1279,21 @@ users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpr
 
 users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpreter.Label',
 'testing', {
-	isLabel: true,
+    isLabel: true,
 },
 'initializing', {
-	initialize: function($super, pos, name) {
-		this.pos = pos;
-		this.name = name;
+    initialize: function($super, pos, name) {
+        this.pos = pos;
+        this.name = name;
 
-	},
+    },
 },
 'debugging', {
-	printConstruction: function () { return this.printConstructorCall(this.pos, '"' + this.name + '"') },
-	toString: function () { return Strings.format('%s(%s)', this.constructor.name, this.name) },
+    printConstruction: function () { return this.printConstructorCall(this.pos, '"' + this.name + '"') },
+    toString: function () { return Strings.format('%s(%s)', this.constructor.name, this.name) },
 },
 'conversion', {
-	asJS: function (depth) { return this.name; },
+    asJS: function (depth) { return this.name; },
 },
 'visiting', {
     accept: function(visitor) {
@@ -1303,22 +1303,22 @@ users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpr
 
 users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpreter.LabelDeclaration',
 'testing', {
-	isLabelDeclaration: true,
+    isLabelDeclaration: true,
 },
 'initializing', {
-	initialize: function($super, pos, name, expr) {
-		this.pos = pos;
-		this.name = name;
-		this.expr = expr;
-		expr.setParent(this);
-	},
+    initialize: function($super, pos, name, expr) {
+        this.pos = pos;
+        this.name = name;
+        this.expr = expr;
+        expr.setParent(this);
+    },
 },
 'debugging', {
-	printConstruction: function () { return this.printConstructorCall(this.pos, '"' + this.name + '"', this.expr) },
-	toString: function () { return Strings.format('%s(%s is %s)', this.constructor.name, this.name, this.expr) },
+    printConstruction: function () { return this.printConstructorCall(this.pos, '"' + this.name + '"', this.expr) },
+    toString: function () { return Strings.format('%s(%s is %s)', this.constructor.name, this.name, this.expr) },
 },
 'conversion', {
-	asJS: function (depth) { return this.name + ': ' + this.expr.asJS(depth) },
+    asJS: function (depth) { return this.name + ': ' + this.expr.asJS(depth) },
 },
 'visiting', {
     accept: function(visitor) {
@@ -1328,48 +1328,48 @@ users.timfelgentreff.jsinterpreter.Node.subclass('users.timfelgentreff.jsinterpr
 
 Object.subclass('users.timfelgentreff.jsinterpreter.Visitor',
 'visiting', {
-	visit: function(node) { return node.accept(this) },
-	visitSequence: function(node) {},
-	visitNumber: function(node) {},
-	visitString: function(node) {},
-	visitCond: function(node) {},
-	visitIf: function(node) {},
-	visitWhile: function(node) {},
-	visitDoWhile: function(node) {},
-	visitFor: function(node) {},
-	visitForIn: function(node) {},
-	visitSet: function(node) {},
-	visitModifyingSet: function(node) {},
-	visitBinaryOp: function(node) {},
-	visitUnaryOp: function(node) {},
-	visitPreOp: function(node) {},
-	visitPostOp: function(node) {},
-	visitThis: function(node) {},
-	visitVariable: function(node) {},
-	visitGetSlot: function(node) {},
-	visitBreak: function(node) {},
-	visitDebugger: function(node) {},
-	visitContinue: function(node) {},
-	visitArrayLiteral: function(node) {},
-	visitReturn: function(node) {},
-	visitWith: function(node) {},
-	visitSend: function(node) {},
-	visitCall: function(node) {},
-	visitNew: function(node) {},
-	visitVarDeclaration: function(node) {},
-	visitThrow: function(node) {},
-	visitTryCatchFinally: function(node) {},
-	visitFunction: function(node) {},
-	visitObjectLiteral: function(node) {},
-	visitObjProperty: function(node) {},
-	visitObjPropertyGet: function(node) {},
-	visitObjPropertySet: function(node) {},
-	visitSwitch: function(node) {},
-	visitCase: function(node) {},
-	visitDefault: function(node) {},
-	visitRegex: function(node) {},
-	visitLabel: function(node) {},
-	visitLabelDeclaration: function(node) {},
+    visit: function(node) { return node.accept(this) },
+    visitSequence: function(node) {},
+    visitNumber: function(node) {},
+    visitString: function(node) {},
+    visitCond: function(node) {},
+    visitIf: function(node) {},
+    visitWhile: function(node) {},
+    visitDoWhile: function(node) {},
+    visitFor: function(node) {},
+    visitForIn: function(node) {},
+    visitSet: function(node) {},
+    visitModifyingSet: function(node) {},
+    visitBinaryOp: function(node) {},
+    visitUnaryOp: function(node) {},
+    visitPreOp: function(node) {},
+    visitPostOp: function(node) {},
+    visitThis: function(node) {},
+    visitVariable: function(node) {},
+    visitGetSlot: function(node) {},
+    visitBreak: function(node) {},
+    visitDebugger: function(node) {},
+    visitContinue: function(node) {},
+    visitArrayLiteral: function(node) {},
+    visitReturn: function(node) {},
+    visitWith: function(node) {},
+    visitSend: function(node) {},
+    visitCall: function(node) {},
+    visitNew: function(node) {},
+    visitVarDeclaration: function(node) {},
+    visitThrow: function(node) {},
+    visitTryCatchFinally: function(node) {},
+    visitFunction: function(node) {},
+    visitObjectLiteral: function(node) {},
+    visitObjProperty: function(node) {},
+    visitObjPropertyGet: function(node) {},
+    visitObjPropertySet: function(node) {},
+    visitSwitch: function(node) {},
+    visitCase: function(node) {},
+    visitDefault: function(node) {},
+    visitRegex: function(node) {},
+    visitLabel: function(node) {},
+    visitLabelDeclaration: function(node) {},
 
 })
 });

--- a/ometa/ChunkParser.js
+++ b/ometa/ChunkParser.js
@@ -72,7 +72,7 @@ Global.ChunkParser = {
   parseString: function() {
     var string1Opened;
     var string2Opened;
-	if (this.chunkStart === '\'' || this.chunkStart === '"') return;
+    if (this.chunkStart === '\'' || this.chunkStart === '"') return;
     if (this.next === '\'') string1Opened = true;
     if (this.next === '"') string2Opened = true;
     if (!string1Opened && !string2Opened) return;
@@ -105,9 +105,9 @@ Global.ChunkParser = {
   parseRest: function() {
     this.parseEscapedChar();
     if (!this.isString) {
-	    this.parseRegex();
-	    this.parseString();
-	    this.parseComment();
+        this.parseRegex();
+        this.parseString();
+        this.parseComment();
     }
     if (this.next === this.chunkEnd && this.counter === 0) // end
       return true;

--- a/reactive/reactive.js
+++ b/reactive/reactive.js
@@ -1,348 +1,348 @@
 module('users.timfelgentreff.reactive.reactive').requires('users.timfelgentreff.babelsberg.constraintinterpreter', 'cop.Layers').toRun(function() {
 
-	JSLoader.loadJs(module('users.timfelgentreff.csp.underscore-min').uri());
+    JSLoader.loadJs(module('users.timfelgentreff.csp.underscore-min').uri());
 
-	/***************************************************************
-	 * Abstract Reactive Solver
-	 ***************************************************************/
-	
-	Object.subclass("ReactiveSolver", {
-	    isConstraintObject: true,
-	    constraintVariableFor: function(value, ivarname, bbbCVar) {
-	    	return new ReactiveSolver.Variable(this, value, ivarname, bbbCVar);
-	    },
-	    weight: 10000
-	});
-	
-	Object.subclass("ReactiveSolver.Variable", {
-	    isConstraintObject: true,
-		initialize: function(solver, value, ivarname, bbbCVar) {
-			this.solver = solver;
-			this.__val__ = value;
-		},
-	    suggestValue: function(value) {
-			if(this.__val__ === value) { return value; }
-			var prev = this.__val__;
-	    	this.__val__ = value;
-			try {
-				this.solver.solve();
-			} catch(e) {
-				// revert value in case of a violated assertion
-				if(e instanceof ContinuousAssertError) {
-					this.__val__ = prev;
-				}
-				throw e;
-			}
+    /***************************************************************
+     * Abstract Reactive Solver
+     ***************************************************************/
+    
+    Object.subclass("ReactiveSolver", {
+        isConstraintObject: true,
+        constraintVariableFor: function(value, ivarname, bbbCVar) {
+            return new ReactiveSolver.Variable(this, value, ivarname, bbbCVar);
+        },
+        weight: 10000
+    });
+    
+    Object.subclass("ReactiveSolver.Variable", {
+        isConstraintObject: true,
+        initialize: function(solver, value, ivarname, bbbCVar) {
+            this.solver = solver;
+            this.__val__ = value;
+        },
+        suggestValue: function(value) {
+            if(this.__val__ === value) { return value; }
+            var prev = this.__val__;
+            this.__val__ = value;
+            try {
+                this.solver.solve();
+            } catch(e) {
+                // revert value in case of a violated assertion
+                if(e instanceof ContinuousAssertError) {
+                    this.__val__ = prev;
+                }
+                throw e;
+            }
 
-			// re-constrain variables
-			if (typeof(value) == 'object' || typeof(value) == 'function') {
-			    // only recalculate to reconstraint complex objects
+            // re-constrain variables
+            if (typeof(value) == 'object' || typeof(value) == 'function') {
+                // only recalculate to reconstraint complex objects
                 var bbbConstraint = this.solver.constraint.bbbConstraint;
                 var enabled = bbbConstraint._enabled;
                 bbbConstraint.initialize(bbbConstraint.predicate, bbbConstraint.solver);
                 bbbConstraint.addPrimitiveConstraint(this.solver.constraint);
                 if(enabled) bbbConstraint.enable();
-			}
+            }
 
-	    	return this.__val__;
-	    },
-	    value: function() {
-	    	return this.__val__;
-	    },
-	    setReadonly: function(bool) {
-	    	this.readonly = bool;
-	    },
-	    isReadonly: function() {
-	        return this.readonly;
-	    },
-	    cnEquals: function() {
-	        return new ReactiveSolver.PrimitiveConstraint(this, arguments);
-	    }
-	});
-	
-	Object.subclass("ReactiveSolver.PrimitiveConstraint", {
-	    isConstraintObject: true,
-	    initialize: function(variable, args) {
-			this.enabled = false;
-	    	this.solver = variable.solver;
-	    },
-	    enable: function() {
-			this.enabled = true;
-	    },
-	    disable: function() {
-			this.enabled = false;
-	    }
-	});
-	
-	Object.subclass("ReactiveSolver.Constraint", {
-	    isConstraintObject: true,
-	    initialize: function(solver, bbbConstraint, func) {
-			this.enabled = false;
-	    	this.solver = solver;
-	    	this.solver.constraint = this;
-			this.bbbConstraint = bbbConstraint;
+            return this.__val__;
+        },
+        value: function() {
+            return this.__val__;
+        },
+        setReadonly: function(bool) {
+            this.readonly = bool;
+        },
+        isReadonly: function() {
+            return this.readonly;
+        },
+        cnEquals: function() {
+            return new ReactiveSolver.PrimitiveConstraint(this, arguments);
+        }
+    });
+    
+    Object.subclass("ReactiveSolver.PrimitiveConstraint", {
+        isConstraintObject: true,
+        initialize: function(variable, args) {
+            this.enabled = false;
+            this.solver = variable.solver;
+        },
+        enable: function() {
+            this.enabled = true;
+        },
+        disable: function() {
+            this.enabled = false;
+        }
+    });
+    
+    Object.subclass("ReactiveSolver.Constraint", {
+        isConstraintObject: true,
+        initialize: function(solver, bbbConstraint, func) {
+            this.enabled = false;
+            this.solver = solver;
+            this.solver.constraint = this;
+            this.bbbConstraint = bbbConstraint;
 
-	    	this.predicate = func;
-	    },
-	    enable: function() {
-			this.enabled = true;
-	    },
-	    disable: function() {
-			this.enabled = false;
-	    }
-	});
-	
-	/***************************************************************
-	 * Continuous asserts
-	 ***************************************************************/
-	
-	// TODO: integration with other solvers
-	
-	Error.subclass("ContinuousAssertError", {
-		initialize: function ContinuousAssertError(msg) {
-			if (Error.captureStackTrace) {
-				Error.captureStackTrace(this, ContinuousAssertError);
-			} else {
-				this.stack = (new Error).stack || '';
-			}
-			this.message = msg;
-		},
-		name: "ContinuousAssertError"
-	});
-	
-	ReactiveSolver.subclass("AssertSolver", {
-		initialize: function(message) {
-			this.message = message;
-		},
-	    always: function(opts, func) {
-	        var ctx = opts.ctx;
-	        func.varMapping = ctx;
-	        var cobj = new Constraint(func, this);
-			cobj.allowFailing = true;
-	        cobj.addPrimitiveConstraint(new ReactiveSolver.Constraint(this, cobj, func));
-			try {
-				if(!opts.postponeEnabling) { cobj.enable(); }
-			} catch(e) {
-				if(e instanceof ContinuousAssertError) {
-					cobj.disable();
-				}
-				throw e;
-			}
-	        return cobj;
-	    },
-	    solve: function() {
-	    	if(this.constraint && this.constraint.enabled && typeof this.constraint.predicate === "function")
-	    		if(!this.constraint.predicate())
-	    			throw new ContinuousAssertError(this.message);
-	    }
-	});
+            this.predicate = func;
+        },
+        enable: function() {
+            this.enabled = true;
+        },
+        disable: function() {
+            this.enabled = false;
+        }
+    });
+    
+    /***************************************************************
+     * Continuous asserts
+     ***************************************************************/
+    
+    // TODO: integration with other solvers
+    
+    Error.subclass("ContinuousAssertError", {
+        initialize: function ContinuousAssertError(msg) {
+            if (Error.captureStackTrace) {
+                Error.captureStackTrace(this, ContinuousAssertError);
+            } else {
+                this.stack = (new Error).stack || '';
+            }
+            this.message = msg;
+        },
+        name: "ContinuousAssertError"
+    });
+    
+    ReactiveSolver.subclass("AssertSolver", {
+        initialize: function(message) {
+            this.message = message;
+        },
+        always: function(opts, func) {
+            var ctx = opts.ctx;
+            func.varMapping = ctx;
+            var cobj = new Constraint(func, this);
+            cobj.allowFailing = true;
+            cobj.addPrimitiveConstraint(new ReactiveSolver.Constraint(this, cobj, func));
+            try {
+                if(!opts.postponeEnabling) { cobj.enable(); }
+            } catch(e) {
+                if(e instanceof ContinuousAssertError) {
+                    cobj.disable();
+                }
+                throw e;
+            }
+            return cobj;
+        },
+        solve: function() {
+            if(this.constraint && this.constraint.enabled && typeof this.constraint.predicate === "function")
+                if(!this.constraint.predicate())
+                    throw new ContinuousAssertError(this.message);
+        }
+    });
 ReactiveSolver.subclass("RecalculateSolver", {
-		initialize: function(message) {
-			this.message = message;
-		},
-	    always: function(opts, func) {
-	        var ctx = opts.ctx;
-	        func.varMapping = ctx;
-	        this.constraint = new Constraint(func, this);
-	        this.predicate = func;
-			this.constraint.allowFailing = true;
-			try {
-				if(!opts.postponeEnabling) { this.constraint.enable(); }
-			} catch(e) {
-				if(e instanceof ContinuousAssertError) {
-					this.constraint.disable();
-				}
-				throw e;
-			}
-	        return this.constraint;
-	    },
-	    solve: function() {
-	        debugger
-	    	if(this.constraint && this.constraint.enabled)
-	    		this.constraint.bbbConstraint.initialize(this.constraint.predicate, this);
-	    }
-	});
+        initialize: function(message) {
+            this.message = message;
+        },
+        always: function(opts, func) {
+            var ctx = opts.ctx;
+            func.varMapping = ctx;
+            this.constraint = new Constraint(func, this);
+            this.predicate = func;
+            this.constraint.allowFailing = true;
+            try {
+                if(!opts.postponeEnabling) { this.constraint.enable(); }
+            } catch(e) {
+                if(e instanceof ContinuousAssertError) {
+                    this.constraint.disable();
+                }
+                throw e;
+            }
+            return this.constraint;
+        },
+        solve: function() {
+            debugger
+            if(this.constraint && this.constraint.enabled)
+                this.constraint.bbbConstraint.initialize(this.constraint.predicate, this);
+        }
+    });
 Object.extend(Babelsberg.prototype, {
-		assert: function(opts, func) {
-			opts.solver = new AssertSolver(opts.message);
-			opts.allowUnsolvableOperations = true;
-			opts.allowTests = true;
-			//opts.debugging = true;
-	        return this.always(opts, func);
-		}
-	});
+        assert: function(opts, func) {
+            opts.solver = new AssertSolver(opts.message);
+            opts.allowUnsolvableOperations = true;
+            opts.allowTests = true;
+            //opts.debugging = true;
+            return this.always(opts, func);
+        }
+    });
 
-	/***************************************************************
-	 * Triggering
-	 ***************************************************************/
-	AssertSolver.subclass("TriggerSolver", {
-		initialize: function(callback) {
-			this.callback = callback;
-			this.triggeredOnce = false;
-		},
-	    always: function(opts, func) {
-	        var ctx = opts.ctx;
-	        func.varMapping = ctx;
-	        var cobj = new Constraint(func, this);
-			cobj.allowFailing = true;
-	        cobj.addPrimitiveConstraint(new ReactiveSolver.Constraint(this, cobj, func));
-			if(!opts.postponeEnabling) { cobj.enable(); }
-	        return cobj;
-	    },
-	    solve: function() {
-	    	if(this.constraint &&
-				this.constraint.enabled &&
-				typeof this.constraint.predicate === "function"
-			) {
-	    		if(this.constraint.predicate()) {
-					if(!this.triggeredOnce) {
-						this.triggeredOnce = true;
-						bbb.addCallback(this.callback, this.constraint.bbbConstraint, []);
-					}
-				} else {
-					this.triggeredOnce = false;
-				}
-			}
-	    },
-	    weight: 10
-	});
-	
-	AssertSolver.subclass("__TriggerDefinition__", {
-		initialize: function(opts, func) {
-			this.opts = opts;
-			this.func = func;
-		},
-	    trigger: function(callback) {
-			this.opts.callback = callback;
-			return bbb.trigger(this.opts, this.func);
-		}
-	});
+    /***************************************************************
+     * Triggering
+     ***************************************************************/
+    AssertSolver.subclass("TriggerSolver", {
+        initialize: function(callback) {
+            this.callback = callback;
+            this.triggeredOnce = false;
+        },
+        always: function(opts, func) {
+            var ctx = opts.ctx;
+            func.varMapping = ctx;
+            var cobj = new Constraint(func, this);
+            cobj.allowFailing = true;
+            cobj.addPrimitiveConstraint(new ReactiveSolver.Constraint(this, cobj, func));
+            if(!opts.postponeEnabling) { cobj.enable(); }
+            return cobj;
+        },
+        solve: function() {
+            if(this.constraint &&
+                this.constraint.enabled &&
+                typeof this.constraint.predicate === "function"
+            ) {
+                if(this.constraint.predicate()) {
+                    if(!this.triggeredOnce) {
+                        this.triggeredOnce = true;
+                        bbb.addCallback(this.callback, this.constraint.bbbConstraint, []);
+                    }
+                } else {
+                    this.triggeredOnce = false;
+                }
+            }
+        },
+        weight: 10
+    });
+    
+    AssertSolver.subclass("__TriggerDefinition__", {
+        initialize: function(opts, func) {
+            this.opts = opts;
+            this.func = func;
+        },
+        trigger: function(callback) {
+            this.opts.callback = callback;
+            return bbb.trigger(this.opts, this.func);
+        }
+    });
 
-	Object.extend(Babelsberg.prototype, {
-		trigger: function(opts, func) {
-			opts.solver = new TriggerSolver(opts.callback);
-			opts.allowUnsolvableOperations = true;
-			opts.allowTests = true;
-			//opts.debugging = true;
-	        return this.always(opts, func);
-		},
-		when: function(opts, func) {
-			return new __TriggerDefinition__(opts, func);
-		}
-	});
+    Object.extend(Babelsberg.prototype, {
+        trigger: function(opts, func) {
+            opts.solver = new TriggerSolver(opts.callback);
+            opts.allowUnsolvableOperations = true;
+            opts.allowTests = true;
+            //opts.debugging = true;
+            return this.always(opts, func);
+        },
+        when: function(opts, func) {
+            return new __TriggerDefinition__(opts, func);
+        }
+    });
 
-	/***************************************************************
-	 * Layer activation
-	 ***************************************************************/
-	AssertSolver.subclass("LayerActivationSolver", {
-		initialize: function(layer) {
-			this.layer = layer;
-		},
-	    always: function(opts, func) {
-	        var ctx = opts.ctx;
-	        func.varMapping = ctx;
-	        var cobj = new Constraint(func, this);
-			cobj.allowFailing = true;
-	        cobj.addPrimitiveConstraint(new ReactiveSolver.Constraint(this, cobj, func));
-			cobj.enable();
-	        return cobj;
-	    },
-	    solve: function() {
-	    	if(this.constraint &&
-				this.constraint.enabled &&
-				typeof this.constraint.predicate === "function"
-			) {
-				var predicateFulfilled = this.constraint.predicate();
-	    		if(predicateFulfilled && !this.layer.isGlobal()) {
-	    			this.layer.beGlobal();
-				} else  if(!predicateFulfilled && this.layer.isGlobal()) {
-	    			this.layer.beNotGlobal();
-				}
-			}
-	    },
-	    weight: 10
-	});
-	
-	Object.extend(Layer.prototype, {
-		activeOn: function(opts, func) {
-			opts.solver = new LayerActivationSolver(this);
-			opts.allowUnsolvableOperations = true;
-			opts.allowTests = true;
-			//opts.debugging = true;
-	        bbb.always(opts, func);
-			
-			return this;
-		}
-	});
-	
-	/***************************************************************
-	 * Scoped constraints
-	 ***************************************************************/
-	Object.extend(Layer.prototype, {
-		always: function(opts, func) {
-			opts.postponeEnabling = !this.isGlobal();
-			var cobj = bbb.always(opts, func);
+    /***************************************************************
+     * Layer activation
+     ***************************************************************/
+    AssertSolver.subclass("LayerActivationSolver", {
+        initialize: function(layer) {
+            this.layer = layer;
+        },
+        always: function(opts, func) {
+            var ctx = opts.ctx;
+            func.varMapping = ctx;
+            var cobj = new Constraint(func, this);
+            cobj.allowFailing = true;
+            cobj.addPrimitiveConstraint(new ReactiveSolver.Constraint(this, cobj, func));
+            cobj.enable();
+            return cobj;
+        },
+        solve: function() {
+            if(this.constraint &&
+                this.constraint.enabled &&
+                typeof this.constraint.predicate === "function"
+            ) {
+                var predicateFulfilled = this.constraint.predicate();
+                if(predicateFulfilled && !this.layer.isGlobal()) {
+                    this.layer.beGlobal();
+                } else  if(!predicateFulfilled && this.layer.isGlobal()) {
+                    this.layer.beNotGlobal();
+                }
+            }
+        },
+        weight: 10
+    });
+    
+    Object.extend(Layer.prototype, {
+        activeOn: function(opts, func) {
+            opts.solver = new LayerActivationSolver(this);
+            opts.allowUnsolvableOperations = true;
+            opts.allowTests = true;
+            //opts.debugging = true;
+            bbb.always(opts, func);
+            
+            return this;
+        }
+    });
+    
+    /***************************************************************
+     * Scoped constraints
+     ***************************************************************/
+    Object.extend(Layer.prototype, {
+        always: function(opts, func) {
+            opts.postponeEnabling = !this.isGlobal();
+            var cobj = bbb.always(opts, func);
 
-			this.constraintObjects = this.constraintObjects || [];
-			this.constraintObjects.push(cobj);
-		},
-		assert: function(opts, func) {
-			opts.postponeEnabling = !this.isGlobal();
-			var cobj = bbb.assert(opts, func);
+            this.constraintObjects = this.constraintObjects || [];
+            this.constraintObjects.push(cobj);
+        },
+        assert: function(opts, func) {
+            opts.postponeEnabling = !this.isGlobal();
+            var cobj = bbb.assert(opts, func);
 
-			this.constraintObjects = this.constraintObjects || [];
-			this.constraintObjects.push(cobj);
-		},
-		trigger: function(opts, func) {
-			opts.postponeEnabling = !this.isGlobal();
-			var cobj = bbb.trigger(opts, func);
+            this.constraintObjects = this.constraintObjects || [];
+            this.constraintObjects.push(cobj);
+        },
+        trigger: function(opts, func) {
+            opts.postponeEnabling = !this.isGlobal();
+            var cobj = bbb.trigger(opts, func);
 
-			this.constraintObjects = this.constraintObjects || [];
-			this.constraintObjects.push(cobj);
-		},
-		_activate: function() {
-			this.constraintObjects = this.constraintObjects || [];
-			this.constraintObjects.forEach(function(cobj) {
-				cobj.enable();
-			});
-		},
-		_deactivate: function() {
-			this.constraintObjects = this.constraintObjects || [];
-			this.constraintObjects.forEach(function(cobj) {
-				cobj.disable();
-			});
-		}
-	});
+            this.constraintObjects = this.constraintObjects || [];
+            this.constraintObjects.push(cobj);
+        },
+        _activate: function() {
+            this.constraintObjects = this.constraintObjects || [];
+            this.constraintObjects.forEach(function(cobj) {
+                cobj.enable();
+            });
+        },
+        _deactivate: function() {
+            this.constraintObjects = this.constraintObjects || [];
+            this.constraintObjects.forEach(function(cobj) {
+                cobj.disable();
+            });
+        }
+    });
 
-	/* Layer Activation */
-	cop.withLayers = cop.withLayers.wrap(function(callOriginal, layers, func) {
-		layers.forEach(function(layer) { layer._activate(); });
+    /* Layer Activation */
+    cop.withLayers = cop.withLayers.wrap(function(callOriginal, layers, func) {
+        layers.forEach(function(layer) { layer._activate(); });
 
-		try {
-			return callOriginal(layers, func);
-		} finally {
-			layers.forEach(function(layer) { layer._deactivate(); });
-		}
-	});
+        try {
+            return callOriginal(layers, func);
+        } finally {
+            layers.forEach(function(layer) { layer._deactivate(); });
+        }
+    });
 
-	cop.withoutLayers = cop.withoutLayers.wrap(function(callOriginal, layers, func) {
-		layers.forEach(function(layer) { layer._deactivate(); });
-		
-		try {
-			return callOriginal(layers, func);
-		} finally {
-			layers.forEach(function(layer) { layer._activate(); });
-		}
-	});
+    cop.withoutLayers = cop.withoutLayers.wrap(function(callOriginal, layers, func) {
+        layers.forEach(function(layer) { layer._deactivate(); });
+        
+        try {
+            return callOriginal(layers, func);
+        } finally {
+            layers.forEach(function(layer) { layer._activate(); });
+        }
+    });
 
-	/* Global Layer Activation */
-	cop.enableLayer = cop.enableLayer.wrap(function(callOriginal, layer) {
-		layer._activate();
-		return callOriginal(layer);
-	});
+    /* Global Layer Activation */
+    cop.enableLayer = cop.enableLayer.wrap(function(callOriginal, layer) {
+        layer._activate();
+        return callOriginal(layer);
+    });
 
-	cop.disableLayer = cop.disableLayer.wrap(function(callOriginal, layer) {
-		layer._deactivate();
-		return callOriginal(layer);
-	});
+    cop.disableLayer = cop.disableLayer.wrap(function(callOriginal, layer) {
+        layer._deactivate();
+        return callOriginal(layer);
+    });
 });

--- a/reactive/reactive_test.js
+++ b/reactive/reactive_test.js
@@ -1,357 +1,357 @@
 module('users.timfelgentreff.reactive.reactive_test').requires('lively.TestFramework', 'users.timfelgentreff.reactive.reactive').toRun(function() {
 
 TestCase.subclass('users.timfelgentreff.reactive.reactive_test.AssertTest', {
-	setUp: function() {
-		_Point = function(x, y) {
-			this.x = x;
-			this.y = y;
-		};
-		_Point.prototype.distance = function(ext) {
-			var distX = ext.x - this.x;
-			var distY = ext.y - this.y;
-			return Math.sqrt(distX * distX + distY * distY);
-		};
-		_Point.prototype.extent = function(ext) {
-			return new Rectangle(this.x, this.y, ext.x, ext.y);
-		};
-		_Point.prototype.leq = function(other) {
-			return this.x <= other.x && this.y <= other.y;
-		}
-		_Point.prototype.add = function(other) {
-			var x = this.x + other.x;
-			var y = this.y + other.y;
-			return new _Point(x, y);
-		};
-		
-		_Rectangle = function(left, bottom, width, height) {
-			this.origin = new _Point(left, bottom);
-			this.extent = new _Point(width, height);
-		};
-		_Rectangle.prototype.contains = function(point) {
-			var upperRightCorner = this.origin.add(this.extent);
-			return this.origin.leq(point) &&
-				point.leq(upperRightCorner);
-		};
-	},
-	assertWithError: function(ErrorType, func, msg) {
-		var errorThrown = false;
-		try {
-			func();
-		} catch(e) {
-			if(e instanceof ErrorType) {
-				errorThrown = true;
-			} else {
-				throw e;
-			}
-		}
-		this.assert(errorThrown, msg);
-	},
+    setUp: function() {
+        _Point = function(x, y) {
+            this.x = x;
+            this.y = y;
+        };
+        _Point.prototype.distance = function(ext) {
+            var distX = ext.x - this.x;
+            var distY = ext.y - this.y;
+            return Math.sqrt(distX * distX + distY * distY);
+        };
+        _Point.prototype.extent = function(ext) {
+            return new Rectangle(this.x, this.y, ext.x, ext.y);
+        };
+        _Point.prototype.leq = function(other) {
+            return this.x <= other.x && this.y <= other.y;
+        }
+        _Point.prototype.add = function(other) {
+            var x = this.x + other.x;
+            var y = this.y + other.y;
+            return new _Point(x, y);
+        };
+        
+        _Rectangle = function(left, bottom, width, height) {
+            this.origin = new _Point(left, bottom);
+            this.extent = new _Point(width, height);
+        };
+        _Rectangle.prototype.contains = function(point) {
+            var upperRightCorner = this.origin.add(this.extent);
+            return this.origin.leq(point) &&
+                point.leq(upperRightCorner);
+        };
+    },
+    assertWithError: function(ErrorType, func, msg) {
+        var errorThrown = false;
+        try {
+            func();
+        } catch(e) {
+            if(e instanceof ErrorType) {
+                errorThrown = true;
+            } else {
+                throw e;
+            }
+        }
+        this.assert(errorThrown, msg);
+    },
     testAssertSolver: function() {
-    	var pt = {x: 1, y: 2};
-    	
-    	bbb.assert({
-			message: "expected error",
-    		ctx: {
-    			pt: pt
-    		}
-    	}, function() {
-   			return pt.y > pt.x;
-    	});
-		this.assert(pt.x === 1, "constraint construction modified variable, pt.x: " + pt.x);
-		this.assert(pt.y === 2, "constraint construction modified variable, pt.y: " + pt.y);
-
-		// valid assignment
-		pt.x = 0;
-		this.assert(pt.x === 0, "assignment did not work, pt.x: " + pt.x);
-		this.assert(pt.y === 2, "modified unassigned variable, pt.y: " + pt.y);
-		
-		// invalid assignment
-		this.assertWithError(
-			ContinuousAssertError,
-			function() { pt.y = -1; },
-			"no ContinuousAssertError was thrown"
-		);
-		this.assert(pt.x === 0, "modified unassigned variable, pt.x: " + pt.x);
-		this.assert(pt.y === 2, "revert did not work, pt.y: " + pt.y);
-    },
-	testFailOnConstraintConstruction: function() {
-    	var pt = {x: 1, y: 2};
-    	
-		this.assertWithError(
-			ContinuousAssertError,
-			function() {
-				bbb.assert({
-					message: "expected error",
-					ctx: {
-						pt: pt
-					}
-				}, function() {
-					return pt.x === pt.y;
-				});
-			},
-			"no ContinuousAssertError was thrown(1)"
-		);
-		this.assert(pt.x === 1, "assertion construction modified variable, pt.x: " + pt.x);
-		this.assert(pt.y === 2, "assertion construction modified variable, pt.y: " + pt.y);
-
-		// valid assignment
-		pt.x = 0;
-		this.assert(pt.x === 0, "assignment did not work, pt.x: " + pt.x);
-		this.assert(pt.y === 2, "modified unassigned variable, pt.y: " + pt.y);
-    },
-	testComplexFunction: function() {
-		var pt1 = new _Point(2,3);
-		var pt2 = new _Point(5,7);
-		this.assert(pt1.distance(pt2) === 5, "distance not correct, distance: " + pt1.distance(pt2));
-		
-		bbb.assert({
-			message: "distance to pt2 point is not 5",
-			ctx: {
-				pt1: pt1,
-				pt2: pt2
-			}
-		}, function() {
-			return pt1.distance(pt2) === 5;
-		});
-		
-		// valid assignment
-		pt2.x = -1;
-		this.assert(pt1.x === 2, "modified unassigned variable, pt1.x: " + pt1.x);
-		this.assert(pt1.y === 3, "modified unassigned variable, pt1.y: " + pt1.y);
-		this.assert(pt2.x === -1, "assignment did not work, pt2.x: " + pt2.x);
-		this.assert(pt2.y === 7, "modified unassigned variable, pt2.y: " + pt2.y);
-
-		// invalid assignment
-		this.assertWithError(
-			ContinuousAssertError,
-			function() {
-				pt2.x = 3;
-			},
-			"no ContinuousAssertError was thrown"
-		);
-		this.assert(pt1.x === 2, "modified unassigned variable, pt1.x: " + pt1.x);
-		this.assert(pt1.y === 3, "modified unassigned variable, pt1.y: " + pt1.y);
-		this.assert(pt2.x === -1, "assignment not reverted, pt2.x: " + pt2.x);
-		this.assert(pt2.y === 7, "modified unassigned variable, pt2.y: " + pt2.y);
-	},
-	testComplexObject: function() {
-		var pt = new _Point(4,4);
-		var rect = new _Rectangle(0, 0, 5, 5);
-
-		this.assert(rect.contains(pt), "pt not contained by rectangle");
-		
-		bbb.assert({
-			message: "rect does not include pt",
-			ctx: {
-				rect: rect,
-				pt: pt
-			}
-		}, function() {
-			return rect.contains(pt);
-		});
-		
-		this.assertWithError(
-			ContinuousAssertError,
-			function() {
-				rect.origin = new _Point(3,4.5);
-			},
-			"no ContinuousAssertError was thrown (1)"
-		);
-		this.assert(rect.origin.x === 0, "assignment not reverted, rect.origin.x: " + rect.origin.x);
-		this.assert(rect.origin.y === 0, "assignment not reverted, rect.origin.y: " + rect.origin.y);
-		this.assert(rect.extent.x === 5, "assignment modified unrelated variables, rect.extent.x: " + rect.extent.x);
-		this.assert(rect.extent.y === 5, "assignment modified unrelated variables, rect.extent.y: " + rect.extent.y);
-		this.assert(pt.x === 4, "assignment modified unrelated variables, pt.x: " + pt.x);
-		this.assert(pt.y === 4, "assignment modified unrelated variables, pt.y: " + pt.y);
+        var pt = {x: 1, y: 2};
+        
+        bbb.assert({
+            message: "expected error",
+            ctx: {
+                pt: pt
+            }
+        }, function() {
+               return pt.y > pt.x;
+        });
+        this.assert(pt.x === 1, "constraint construction modified variable, pt.x: " + pt.x);
+        this.assert(pt.y === 2, "constraint construction modified variable, pt.y: " + pt.y);
 
         // valid assignment
-		pt.y = 4.5;
-		this.assert(rect.origin.x === 0, "assignment modified unrelated variables, rect.origin.x: " + rect.origin.x);
-		this.assert(rect.origin.y === 0, "assignment modified unrelated variables, rect.origin.y: " + rect.origin.y);
-		this.assert(rect.extent.x === 5, "assignment modified unrelated variables, rect.extent.x: " + rect.extent.x);
-		this.assert(rect.extent.y === 5, "assignment modified unrelated variables, rect.extent.y: " + rect.extent.y);
-		this.assert(pt.x === 4, "assignment modified unrelated variables, pt.x: " + pt.x);
-		this.assert(pt.y === 4.5, "assignment did not work, pt.y: " + pt.y);
-
-		this.assertWithError(
-			ContinuousAssertError,
-			function() {
-				rect.origin.x = 4.5;
-			},
-			"no ContinuousAssertError was thrown (2)"
-		);
-		this.assert(rect.origin.x === 0, "assignment not reverted, rect.origin.x: " + rect.origin.x);
-		this.assert(rect.origin.y === 0, "assignment modified unrelated variables, rect.origin.y: " + rect.origin.y);
-		this.assert(rect.extent.x === 5, "assignment modified unrelated variables, rect.extent.x: " + rect.extent.x);
-		this.assert(rect.extent.y === 5, "assignment modified unrelated variables, rect.extent.y: " + rect.extent.y);
-		this.assert(pt.x === 4, "assignment modified unrelated variables, pt.x: " + pt.x);
-		this.assert(pt.y === 4.5, "assignment modified unrelated variables, pt.y: " + pt.y);
-
-		rect.origin = new _Point(3,3);
-		this.assert(rect.origin.x === 3, "assignment did not work, rect.origin.x: " + rect.origin.x);
-		this.assert(rect.origin.y === 3, "assignment did not work, rect.origin.y: " + rect.origin.y);
-		this.assert(rect.extent.x === 5, "assignment modified unrelated variables, rect.extent.x: " + rect.extent.x);
-		this.assert(rect.extent.y === 5, "assignment modified unrelated variables, rect.extent.y: " + rect.extent.y);
-		this.assert(pt.x === 4, "assignment modified unrelated variables, pt.x: " + pt.x);
-		this.assert(pt.y === 4.5, "assignment modified unrelated variables, pt.y: " + pt.y);
-
-		this.assertWithError(
-			ContinuousAssertError,
-			function() {
-				rect.origin.x = 4.5;
-			},
-			"newly assigned point was not re-constrained"
-		);
-		this.assert(rect.origin.x === 3, "assignment was not reverted, rect.origin.x: " + rect.origin.x);
-		this.assert(rect.origin.y === 3, "assignment modified unrelated variables, rect.origin.y: " + rect.origin.y);
-		this.assert(rect.extent.x === 5, "assignment modified unrelated variables, rect.extent.x: " + rect.extent.x);
-		this.assert(rect.extent.y === 5, "assignment modified unrelated variables, rect.extent.y: " + rect.extent.y);
-		this.assert(pt.x === 4, "assignment modified unrelated variables, pt.x: " + pt.x);
-		this.assert(pt.y === 4.5, "assignment modified unrelated variables, pt.y: " + pt.y);
+        pt.x = 0;
+        this.assert(pt.x === 0, "assignment did not work, pt.x: " + pt.x);
+        this.assert(pt.y === 2, "modified unassigned variable, pt.y: " + pt.y);
+        
+        // invalid assignment
+        this.assertWithError(
+            ContinuousAssertError,
+            function() { pt.y = -1; },
+            "no ContinuousAssertError was thrown"
+        );
+        this.assert(pt.x === 0, "modified unassigned variable, pt.x: " + pt.x);
+        this.assert(pt.y === 2, "revert did not work, pt.y: " + pt.y);
     },
-	testInvalidAssignment: function() {
-    	var pt = {x: 1, y: 2};
-    	
-    	bbb.assert({
-			message: "expected error",
-    		ctx: {
-    			pt: pt
-    		}
-    	}, function() {
-   			return pt.y > pt.x;
-    	});
+    testFailOnConstraintConstruction: function() {
+        var pt = {x: 1, y: 2};
+        
+        this.assertWithError(
+            ContinuousAssertError,
+            function() {
+                bbb.assert({
+                    message: "expected error",
+                    ctx: {
+                        pt: pt
+                    }
+                }, function() {
+                    return pt.x === pt.y;
+                });
+            },
+            "no ContinuousAssertError was thrown(1)"
+        );
+        this.assert(pt.x === 1, "assertion construction modified variable, pt.x: " + pt.x);
+        this.assert(pt.y === 2, "assertion construction modified variable, pt.y: " + pt.y);
 
-		this.assertWithError(
-			ContinuousAssertError,
-			function() { pt.y = -1; },
-			"no ContinuousAssertError was thrown"
-		);
-		this.assert(pt.x === 1, "another variable was modified, pt.x: " + pt.x);
-		this.assert(pt.y === 2, "assignment not reverted, pt.y: " + pt.y);
+        // valid assignment
+        pt.x = 0;
+        this.assert(pt.x === 0, "assignment did not work, pt.x: " + pt.x);
+        this.assert(pt.y === 2, "modified unassigned variable, pt.y: " + pt.y);
     },
-	testMultipleAssertionsOnSameObject: function() {
-    	var pt = {x: 1, y: 2};
-
-    	bbb.assert({
-			message: "x-coordinate is not positive",
-    		ctx: {
-    			pt: pt
-    		}
-    	}, function() {
-   			return pt.x >= 0;
-    	});
-    	bbb.assert({
-			message: "x-coordinate is greater then 10",
-    		ctx: {
-    			pt: pt
-    		}
-    	}, function() {
-   			return pt.x <= 10;
-    	});
-		this.assert(pt.x === 1, "constraint construction modified variable, pt.x: " + pt.x);
-
-		// valid assignment
-		pt.x = 7;
-		this.assert(pt.x === 7, "assignment did not work, pt.x: " + pt.x);
-
-		// invalid assignment with respect to first assertion
-		this.assertWithError(
-			ContinuousAssertError,
-			function() { pt.x = -1; },
-			"no ContinuousAssertError was thrown"
-		);
-		this.assert(pt.x === 7, "assignment not reverted(1), pt.x: " + pt.x);
-
-		// invalid assignment with respect to second assertion
-		this.assertWithError(
-			ContinuousAssertError,
-			function() { pt.x = 11; },
-			"no ContinuousAssertError was thrown"
-		);
-		this.assert(pt.x === 7, "assignment not reverted(2), pt.x: " + pt.x);
-    },
-	testIntegrationWithOtherSolvers_FailOnAssignment: function() {
-	    var pt = {x: 1, y: 2},
-			cassowary = new ClSimplexSolver();
-
-		cassowary.weight = -999;
-    	bbb.always({
-			solver: cassowary,
-    		ctx: {
-    			pt: pt
-    		}
-    	}, function() {
-   			return pt.x == pt.y;
-    	});
-		var eX = pt.x, eY = pt.y;
-		this.assert(eX == eY, "Cassowary doesnt work");
-    	bbb.assert({
-			message: "expected error",
-    		ctx: {
-    			pt: pt
-    		}
-    	}, function() {
-   			return pt.x <= 10;
-    	});
+    testComplexFunction: function() {
+        var pt1 = new _Point(2,3);
+        var pt2 = new _Point(5,7);
+        this.assert(pt1.distance(pt2) === 5, "distance not correct, distance: " + pt1.distance(pt2));
+        
+        bbb.assert({
+            message: "distance to pt2 point is not 5",
+            ctx: {
+                pt1: pt1,
+                pt2: pt2
+            }
+        }, function() {
+            return pt1.distance(pt2) === 5;
+        });
+        
+        // valid assignment
+        pt2.x = -1;
+        this.assert(pt1.x === 2, "modified unassigned variable, pt1.x: " + pt1.x);
+        this.assert(pt1.y === 3, "modified unassigned variable, pt1.y: " + pt1.y);
+        this.assert(pt2.x === -1, "assignment did not work, pt2.x: " + pt2.x);
+        this.assert(pt2.y === 7, "modified unassigned variable, pt2.y: " + pt2.y);
 
         // invalid assignment
-		this.assertWithError(
-			ContinuousAssertError,
-			function() { pt.x = 100; },
-			"no ContinuousAssertError was thrown"
-		);
-		this.assert(pt.x == eX, "assignment did not work, pt.x: " + pt.x);
-		this.assert(pt.y == eY, "constraint did not work, pt.y: " + pt.y);
+        this.assertWithError(
+            ContinuousAssertError,
+            function() {
+                pt2.x = 3;
+            },
+            "no ContinuousAssertError was thrown"
+        );
+        this.assert(pt1.x === 2, "modified unassigned variable, pt1.x: " + pt1.x);
+        this.assert(pt1.y === 3, "modified unassigned variable, pt1.y: " + pt1.y);
+        this.assert(pt2.x === -1, "assignment not reverted, pt2.x: " + pt2.x);
+        this.assert(pt2.y === 7, "modified unassigned variable, pt2.y: " + pt2.y);
     },
-	testIntegrationWithOtherSolvers_FailOnAssignment2: function() {
-	    var pt = {x: 1, y: 2},
-			cassowary = new ClSimplexSolver();
+    testComplexObject: function() {
+        var pt = new _Point(4,4);
+        var rect = new _Rectangle(0, 0, 5, 5);
 
-		cassowary.weight = 10000;
-    	bbb.always({
-			solver: cassowary,
-    		ctx: {
-    			pt: pt
-    		}
-    	}, function() {
-   			return pt.x == pt.y;
-    	});
-		var eX = pt.x, eY = pt.y;
-		this.assert(eX == eY, "Cassowary doesnt work");
-    	bbb.assert({
-			message: "expected error",
-    		ctx: {
-    			pt: pt
-    		}
-    	}, function() {
-   			return pt.x <= 10;
-    	});
+        this.assert(rect.contains(pt), "pt not contained by rectangle");
+        
+        bbb.assert({
+            message: "rect does not include pt",
+            ctx: {
+                rect: rect,
+                pt: pt
+            }
+        }, function() {
+            return rect.contains(pt);
+        });
+        
+        this.assertWithError(
+            ContinuousAssertError,
+            function() {
+                rect.origin = new _Point(3,4.5);
+            },
+            "no ContinuousAssertError was thrown (1)"
+        );
+        this.assert(rect.origin.x === 0, "assignment not reverted, rect.origin.x: " + rect.origin.x);
+        this.assert(rect.origin.y === 0, "assignment not reverted, rect.origin.y: " + rect.origin.y);
+        this.assert(rect.extent.x === 5, "assignment modified unrelated variables, rect.extent.x: " + rect.extent.x);
+        this.assert(rect.extent.y === 5, "assignment modified unrelated variables, rect.extent.y: " + rect.extent.y);
+        this.assert(pt.x === 4, "assignment modified unrelated variables, pt.x: " + pt.x);
+        this.assert(pt.y === 4, "assignment modified unrelated variables, pt.y: " + pt.y);
+
+        // valid assignment
+        pt.y = 4.5;
+        this.assert(rect.origin.x === 0, "assignment modified unrelated variables, rect.origin.x: " + rect.origin.x);
+        this.assert(rect.origin.y === 0, "assignment modified unrelated variables, rect.origin.y: " + rect.origin.y);
+        this.assert(rect.extent.x === 5, "assignment modified unrelated variables, rect.extent.x: " + rect.extent.x);
+        this.assert(rect.extent.y === 5, "assignment modified unrelated variables, rect.extent.y: " + rect.extent.y);
+        this.assert(pt.x === 4, "assignment modified unrelated variables, pt.x: " + pt.x);
+        this.assert(pt.y === 4.5, "assignment did not work, pt.y: " + pt.y);
+
+        this.assertWithError(
+            ContinuousAssertError,
+            function() {
+                rect.origin.x = 4.5;
+            },
+            "no ContinuousAssertError was thrown (2)"
+        );
+        this.assert(rect.origin.x === 0, "assignment not reverted, rect.origin.x: " + rect.origin.x);
+        this.assert(rect.origin.y === 0, "assignment modified unrelated variables, rect.origin.y: " + rect.origin.y);
+        this.assert(rect.extent.x === 5, "assignment modified unrelated variables, rect.extent.x: " + rect.extent.x);
+        this.assert(rect.extent.y === 5, "assignment modified unrelated variables, rect.extent.y: " + rect.extent.y);
+        this.assert(pt.x === 4, "assignment modified unrelated variables, pt.x: " + pt.x);
+        this.assert(pt.y === 4.5, "assignment modified unrelated variables, pt.y: " + pt.y);
+
+        rect.origin = new _Point(3,3);
+        this.assert(rect.origin.x === 3, "assignment did not work, rect.origin.x: " + rect.origin.x);
+        this.assert(rect.origin.y === 3, "assignment did not work, rect.origin.y: " + rect.origin.y);
+        this.assert(rect.extent.x === 5, "assignment modified unrelated variables, rect.extent.x: " + rect.extent.x);
+        this.assert(rect.extent.y === 5, "assignment modified unrelated variables, rect.extent.y: " + rect.extent.y);
+        this.assert(pt.x === 4, "assignment modified unrelated variables, pt.x: " + pt.x);
+        this.assert(pt.y === 4.5, "assignment modified unrelated variables, pt.y: " + pt.y);
+
+        this.assertWithError(
+            ContinuousAssertError,
+            function() {
+                rect.origin.x = 4.5;
+            },
+            "newly assigned point was not re-constrained"
+        );
+        this.assert(rect.origin.x === 3, "assignment was not reverted, rect.origin.x: " + rect.origin.x);
+        this.assert(rect.origin.y === 3, "assignment modified unrelated variables, rect.origin.y: " + rect.origin.y);
+        this.assert(rect.extent.x === 5, "assignment modified unrelated variables, rect.extent.x: " + rect.extent.x);
+        this.assert(rect.extent.y === 5, "assignment modified unrelated variables, rect.extent.y: " + rect.extent.y);
+        this.assert(pt.x === 4, "assignment modified unrelated variables, pt.x: " + pt.x);
+        this.assert(pt.y === 4.5, "assignment modified unrelated variables, pt.y: " + pt.y);
+    },
+    testInvalidAssignment: function() {
+        var pt = {x: 1, y: 2};
+        
+        bbb.assert({
+            message: "expected error",
+            ctx: {
+                pt: pt
+            }
+        }, function() {
+               return pt.y > pt.x;
+        });
+
+        this.assertWithError(
+            ContinuousAssertError,
+            function() { pt.y = -1; },
+            "no ContinuousAssertError was thrown"
+        );
+        this.assert(pt.x === 1, "another variable was modified, pt.x: " + pt.x);
+        this.assert(pt.y === 2, "assignment not reverted, pt.y: " + pt.y);
+    },
+    testMultipleAssertionsOnSameObject: function() {
+        var pt = {x: 1, y: 2};
+
+        bbb.assert({
+            message: "x-coordinate is not positive",
+            ctx: {
+                pt: pt
+            }
+        }, function() {
+               return pt.x >= 0;
+        });
+        bbb.assert({
+            message: "x-coordinate is greater then 10",
+            ctx: {
+                pt: pt
+            }
+        }, function() {
+               return pt.x <= 10;
+        });
+        this.assert(pt.x === 1, "constraint construction modified variable, pt.x: " + pt.x);
+
+        // valid assignment
+        pt.x = 7;
+        this.assert(pt.x === 7, "assignment did not work, pt.x: " + pt.x);
+
+        // invalid assignment with respect to first assertion
+        this.assertWithError(
+            ContinuousAssertError,
+            function() { pt.x = -1; },
+            "no ContinuousAssertError was thrown"
+        );
+        this.assert(pt.x === 7, "assignment not reverted(1), pt.x: " + pt.x);
+
+        // invalid assignment with respect to second assertion
+        this.assertWithError(
+            ContinuousAssertError,
+            function() { pt.x = 11; },
+            "no ContinuousAssertError was thrown"
+        );
+        this.assert(pt.x === 7, "assignment not reverted(2), pt.x: " + pt.x);
+    },
+    testIntegrationWithOtherSolvers_FailOnAssignment: function() {
+        var pt = {x: 1, y: 2},
+            cassowary = new ClSimplexSolver();
+
+        cassowary.weight = -999;
+        bbb.always({
+            solver: cassowary,
+            ctx: {
+                pt: pt
+            }
+        }, function() {
+               return pt.x == pt.y;
+        });
+        var eX = pt.x, eY = pt.y;
+        this.assert(eX == eY, "Cassowary doesnt work");
+        bbb.assert({
+            message: "expected error",
+            ctx: {
+                pt: pt
+            }
+        }, function() {
+               return pt.x <= 10;
+        });
 
         // invalid assignment
-		this.assertWithError(
-			ContinuousAssertError,
-			function() { pt.x = 100; },
-			"no ContinuousAssertError was thrown"
-		);
-		this.assert(pt.x == eX, "assignment did not work, pt.x: " + pt.x);
-		this.assert(pt.y == eY, "constraint did not work, pt.y: " + pt.y);
+        this.assertWithError(
+            ContinuousAssertError,
+            function() { pt.x = 100; },
+            "no ContinuousAssertError was thrown"
+        );
+        this.assert(pt.x == eX, "assignment did not work, pt.x: " + pt.x);
+        this.assert(pt.y == eY, "constraint did not work, pt.y: " + pt.y);
     },
-	testIntegrationWithOtherSolvers_FailOnAssertionConstraintConstruction: function() {
-	    var pt = {x: 1, y: 2};
+    testIntegrationWithOtherSolvers_FailOnAssignment2: function() {
+        var pt = {x: 1, y: 2},
+            cassowary = new ClSimplexSolver();
 
-    	bbb.always({
-			solver: new ClSimplexSolver(),
-    		ctx: {
-    			pt: pt
-    		}
-    	}, function() {
-   			return pt.x == pt.y;
-    	});
-    	pt.x = 100;
+        cassowary.weight = 10000;
+        bbb.always({
+            solver: cassowary,
+            ctx: {
+                pt: pt
+            }
+        }, function() {
+               return pt.x == pt.y;
+        });
+        var eX = pt.x, eY = pt.y;
+        this.assert(eX == eY, "Cassowary doesnt work");
+        bbb.assert({
+            message: "expected error",
+            ctx: {
+                pt: pt
+            }
+        }, function() {
+               return pt.x <= 10;
+        });
 
-		this.assertWithError(
-			ContinuousAssertError,
-			function() {
+        // invalid assignment
+        this.assertWithError(
+            ContinuousAssertError,
+            function() { pt.x = 100; },
+            "no ContinuousAssertError was thrown"
+        );
+        this.assert(pt.x == eX, "assignment did not work, pt.x: " + pt.x);
+        this.assert(pt.y == eY, "constraint did not work, pt.y: " + pt.y);
+    },
+    testIntegrationWithOtherSolvers_FailOnAssertionConstraintConstruction: function() {
+        var pt = {x: 1, y: 2};
+
+        bbb.always({
+            solver: new ClSimplexSolver(),
+            ctx: {
+                pt: pt
+            }
+        }, function() {
+               return pt.x == pt.y;
+        });
+        pt.x = 100;
+
+        this.assertWithError(
+            ContinuousAssertError,
+            function() {
                 bbb.assert({
                     message: "expected error",
                     ctx: {
@@ -360,15 +360,15 @@ TestCase.subclass('users.timfelgentreff.reactive.reactive_test.AssertTest', {
                 }, function() {
                     return pt.x <= 10;
                 });
-			},
-			"no ContinuousAssertError was thrown"
-		);
+            },
+            "no ContinuousAssertError was thrown"
+        );
 
-		this.assert(pt.x == 100, "constraint construction modified variable, pt.x: " + pt.x);
-		this.assert(pt.y == 100, "constraint construction modified variable, pt.y: " + pt.y);
+        this.assert(pt.x == 100, "constraint construction modified variable, pt.x: " + pt.x);
+        this.assert(pt.y == 100, "constraint construction modified variable, pt.y: " + pt.y);
     },
-	testIntegrationWithOtherSolvers_FailOnConstraintConstruction: function() {
-	    var pt = {x: 1, y: 2};
+    testIntegrationWithOtherSolvers_FailOnConstraintConstruction: function() {
+        var pt = {x: 1, y: 2};
 
         bbb.assert({
             message: "expected error",
@@ -378,12 +378,12 @@ TestCase.subclass('users.timfelgentreff.reactive.reactive_test.AssertTest', {
         }, function() {
             return pt.x <= 10;
         });
-		this.assert(pt.x == 1, "constraint construction modified variable, pt.x: " + pt.x);
-		this.assert(pt.y == 2, "constraint construction modified variable, pt.y: " + pt.y);
+        this.assert(pt.x == 1, "constraint construction modified variable, pt.x: " + pt.x);
+        this.assert(pt.y == 2, "constraint construction modified variable, pt.y: " + pt.y);
 
-		this.assertWithError(
-			Error,
-			function() {
+        this.assertWithError(
+            Error,
+            function() {
                 bbb.always({
                     solver: new ClSimplexSolver(),
                     ctx: {
@@ -393,623 +393,623 @@ TestCase.subclass('users.timfelgentreff.reactive.reactive_test.AssertTest', {
                     return pt.x == 100;
                 });
                 console.log(pt.x, pt.y);
-			},
-			"no Error was thrown"
-		);
+            },
+            "no Error was thrown"
+        );
 
-		this.assert(pt.x == 1, "constraint construction modified variable, pt.x: " + pt.x);
-		this.assert(pt.y == 2, "constraint construction modified variable, pt.y: " + pt.y);
+        this.assert(pt.x == 1, "constraint construction modified variable, pt.x: " + pt.x);
+        this.assert(pt.y == 2, "constraint construction modified variable, pt.y: " + pt.y);
     },
 
 });
 
 TestCase.subclass('users.timfelgentreff.reactive.reactive_test.TriggerTest', {
-	setUp: function() {
-		var Player = function(hp) {
-			this.alive = true;
-			this.hp = hp;
-		};
-		Player.prototype.die = function() {
-			this.alive = false;
-		};
+    setUp: function() {
+        var Player = function(hp) {
+            this.alive = true;
+            this.hp = hp;
+        };
+        Player.prototype.die = function() {
+            this.alive = false;
+        };
 
-		this.Player = Player;
-	},
+        this.Player = Player;
+    },
     testTriggerSolver: function() {
-    	var p = new this.Player(2);
-    	
-    	bbb.trigger({
-			callback: p.die.bind(p),
-    		ctx: {
-    			p: p
-    		}
-    	}, function() {
-   			return p.hp <=  0;
-    	});
-		this.assert(p.hp === 2, "constraint construction modified variable, p.hp: " + p.hp);
-		this.assert(p.alive === true, "constraint construction modified variable, p.alive: " + p.alive);
+        var p = new this.Player(2);
+        
+        bbb.trigger({
+            callback: p.die.bind(p),
+            ctx: {
+                p: p
+            }
+        }, function() {
+               return p.hp <=  0;
+        });
+        this.assert(p.hp === 2, "constraint construction modified variable, p.hp: " + p.hp);
+        this.assert(p.alive === true, "constraint construction modified variable, p.alive: " + p.alive);
 
-		// valid assignment
-		p.hp--;
-		this.assert(p.hp === 1, "assignment did not work, p.hp: " + p.hp);
-		this.assert(p.alive === true, "modified unassigned variable, p.alive: " + p.alive);
+        // valid assignment
+        p.hp--;
+        this.assert(p.hp === 1, "assignment did not work, p.hp: " + p.hp);
+        this.assert(p.alive === true, "modified unassigned variable, p.alive: " + p.alive);
 
-		// triggering assignment
-		p.hp--;
-		this.assert(p.hp === 0, "assignment did not work, p.hp: " + p.hp);
-		this.assert(p.alive === false, "desired callback was not triggered");
-	},
+        // triggering assignment
+        p.hp--;
+        this.assert(p.hp === 0, "assignment did not work, p.hp: " + p.hp);
+        this.assert(p.alive === false, "desired callback was not triggered");
+    },
     testRecursiveTriggering: function() {
-		var Domino = function(id, next) {
-			this.id = id;
-			this.next = next;
-			this.standing = true;
-		};
-		Domino.prototype.pushNext = function() {
-			if(this.next instanceof Domino) {
-				this.next.push();
-			}
-		};
-		Domino.prototype.push = function() {
-			this.standing = false;
-		};
-		
-		var domino3 = new Domino(3),
-			domino2 = new Domino(2, domino3),
-			domino1 = new Domino(1, domino2);
-    	
-    	bbb.trigger({
-			callback: domino1.pushNext.bind(domino1),
-    		ctx: {
-    			domino1: domino1
-    		}
-    	}, function() {
-   			return !domino1.standing;
-    	});
-    	bbb.trigger({
-			callback: domino2.pushNext.bind(domino2),
-    		ctx: {
-    			domino2: domino2
-    		}
-    	}, function() {
-   			return !domino2.standing;
-    	});
-    	bbb.trigger({
-			callback: domino3.pushNext.bind(domino3),
-    		ctx: {
-    			domino3: domino3
-    		}
-    	}, function() {
-   			return !domino3.standing;
-    	});
-		
-		domino1.push();
-		this.assert(!domino1.standing, "domino1 still stands");
-		this.assert(!domino2.standing, "domino2 still stands");
-		this.assert(!domino3.standing, "domino3 still stands");
-	},
+        var Domino = function(id, next) {
+            this.id = id;
+            this.next = next;
+            this.standing = true;
+        };
+        Domino.prototype.pushNext = function() {
+            if(this.next instanceof Domino) {
+                this.next.push();
+            }
+        };
+        Domino.prototype.push = function() {
+            this.standing = false;
+        };
+        
+        var domino3 = new Domino(3),
+            domino2 = new Domino(2, domino3),
+            domino1 = new Domino(1, domino2);
+        
+        bbb.trigger({
+            callback: domino1.pushNext.bind(domino1),
+            ctx: {
+                domino1: domino1
+            }
+        }, function() {
+               return !domino1.standing;
+        });
+        bbb.trigger({
+            callback: domino2.pushNext.bind(domino2),
+            ctx: {
+                domino2: domino2
+            }
+        }, function() {
+               return !domino2.standing;
+        });
+        bbb.trigger({
+            callback: domino3.pushNext.bind(domino3),
+            ctx: {
+                domino3: domino3
+            }
+        }, function() {
+               return !domino3.standing;
+        });
+        
+        domino1.push();
+        this.assert(!domino1.standing, "domino1 still stands");
+        this.assert(!domino2.standing, "domino2 still stands");
+        this.assert(!domino3.standing, "domino3 still stands");
+    },
     testImmediateTrigger: function() {
-    	var p = new this.Player(-5);
-    	
-    	bbb.trigger({
-			callback: p.die.bind(p),
-    		ctx: {
-    			p: p
-    		}
-    	}, function() {
-   			return p.hp <=  0;
-    	});
-		this.assert(p.hp === -5, "assignment did not work, p.hp: " + p.hp);
-		this.assert(p.alive === false, "desired callback was not triggered");
-	},
+        var p = new this.Player(-5);
+        
+        bbb.trigger({
+            callback: p.die.bind(p),
+            ctx: {
+                p: p
+            }
+        }, function() {
+               return p.hp <=  0;
+        });
+        this.assert(p.hp === -5, "assignment did not work, p.hp: " + p.hp);
+        this.assert(p.alive === false, "desired callback was not triggered");
+    },
     testOneTimeTrigger: function() {
-    	var p = {
-			hp: 10,
-			lives: 2
-		};
-    	
-    	bbb.trigger({
-			callback: function() {
-				p.lives--;
-			},
-    		ctx: {
-    			p: p
-    		}
-    	}, function() {
-   			return p.hp <=  0;
-    	});
-		this.assert(p.hp === 10, "constraint construction modified variable, p.hp: " + p.hp);
-		this.assert(p.lives === 2, "constraint construction modified variable, p.lives: " + p.lives);
+        var p = {
+            hp: 10,
+            lives: 2
+        };
+        
+        bbb.trigger({
+            callback: function() {
+                p.lives--;
+            },
+            ctx: {
+                p: p
+            }
+        }, function() {
+               return p.hp <=  0;
+        });
+        this.assert(p.hp === 10, "constraint construction modified variable, p.hp: " + p.hp);
+        this.assert(p.lives === 2, "constraint construction modified variable, p.lives: " + p.lives);
 
-		// trigger activation
-		p.hp = -1;
-		this.assert(p.lives === 1, "callback not triggered correctly (1), p.lives: " + p.lives);
+        // trigger activation
+        p.hp = -1;
+        this.assert(p.lives === 1, "callback not triggered correctly (1), p.lives: " + p.lives);
 
-		// no trigger activation
-		p.hp = -2;
-		this.assert(p.lives === 1, "callack activated again without reset, p.lives: " + p.lives);
-	},
+        // no trigger activation
+        p.hp = -2;
+        this.assert(p.lives === 1, "callack activated again without reset, p.lives: " + p.lives);
+    },
     testResetOnFalse: function() {
-    	var p = {
-			hp: 10,
-			lives: 2
-		};
-    	
-    	bbb.trigger({
-			callback: function() {
-				p.lives--;
-				if(p.lives === 0)
-					this.disable();
-			},
-    		ctx: {
-    			p: p
-    		}
-    	}, function() {
-   			return p.hp <=  0;
-    	});
-		this.assert(p.hp === 10, "constraint construction modified variable, p.hp: " + p.hp);
-		this.assert(p.lives === 2, "constraint construction modified variable, p.lives: " + p.lives);
+        var p = {
+            hp: 10,
+            lives: 2
+        };
+        
+        bbb.trigger({
+            callback: function() {
+                p.lives--;
+                if(p.lives === 0)
+                    this.disable();
+            },
+            ctx: {
+                p: p
+            }
+        }, function() {
+               return p.hp <=  0;
+        });
+        this.assert(p.hp === 10, "constraint construction modified variable, p.hp: " + p.hp);
+        this.assert(p.lives === 2, "constraint construction modified variable, p.lives: " + p.lives);
 
-		// valid assignment
-		p.hp = -1;
-		this.assert(p.lives === 1, "callback not triggered correctly (1), p.lives: " + p.lives);
+        // valid assignment
+        p.hp = -1;
+        this.assert(p.lives === 1, "callback not triggered correctly (1), p.lives: " + p.lives);
 
-		p.hp = -2;
-		this.assert(p.lives === 1, "callack activated again without reset, p.lives: " + p.lives);
+        p.hp = -2;
+        this.assert(p.lives === 1, "callack activated again without reset, p.lives: " + p.lives);
 
-		// reactivate trigger
-		p.hp = 10;
-		
-		// calls callback (should disable the trigger)
-		p.hp = -1;
-		this.assert(p.lives === 0, "callback not triggered correctly (2), p.lives: " + p.lives);
+        // reactivate trigger
+        p.hp = 10;
+        
+        // calls callback (should disable the trigger)
+        p.hp = -1;
+        this.assert(p.lives === 0, "callback not triggered correctly (2), p.lives: " + p.lives);
 
-		// for reactivation
-		p.hp = 10;
+        // for reactivation
+        p.hp = 10;
 
-		// non-triggering assignments
-		p.hp = -1;
-		this.assert(p.lives === 0, "callback triggered again, p.lives: " + p.lives);
-	},
+        // non-triggering assignments
+        p.hp = -1;
+        this.assert(p.lives === 0, "callback triggered again, p.lives: " + p.lives);
+    },
     testResetValue: function() {
-    	var p = {
-			hp: 10,
-			lives: 2
-		};
-    	
-    	bbb.trigger({
-			callback: function() {
-				p.lives--;
-				p.hp = 10;
-			},
-    		ctx: {
-    			p: p
-    		}
-    	}, function() {
-   			return p.hp <=  0;
-    	});
-		this.assert(p.lives === 2, "constraint construction modified variable, p.lives: " + p.lives);
-		this.assert(p.hp === 10, "constraint construction modified variable, p.hp: " + p.hp);
+        var p = {
+            hp: 10,
+            lives: 2
+        };
+        
+        bbb.trigger({
+            callback: function() {
+                p.lives--;
+                p.hp = 10;
+            },
+            ctx: {
+                p: p
+            }
+        }, function() {
+               return p.hp <=  0;
+        });
+        this.assert(p.lives === 2, "constraint construction modified variable, p.lives: " + p.lives);
+        this.assert(p.hp === 10, "constraint construction modified variable, p.hp: " + p.hp);
 
-		// valid assignment
-		p.hp = -1;
-		this.assert(p.lives === 1, "callback not triggered correctly (1), p.lives: " + p.lives);
-		this.assert(p.hp === 10, "variable that initiates the trigger could not be reset in callback, p.hp: " + p.hp);
-	},
-	testTriggerIntegrationWithOtherSolvers: function() {
-	    var pt = {x: 1, y: 2, z: 3},
-	        callbackCalled = false;
+        // valid assignment
+        p.hp = -1;
+        this.assert(p.lives === 1, "callback not triggered correctly (1), p.lives: " + p.lives);
+        this.assert(p.hp === 10, "variable that initiates the trigger could not be reset in callback, p.hp: " + p.hp);
+    },
+    testTriggerIntegrationWithOtherSolvers: function() {
+        var pt = {x: 1, y: 2, z: 3},
+            callbackCalled = false;
 
-    	bbb.always({
-			solver: new ClSimplexSolver(),
-    		ctx: {
-    			pt: pt
-    		}
-    	}, function() {
-   			return pt.y == pt.z;
-    	});
-    	bbb.trigger({
-			callback: function() {
-			    callbackCalled = true;
-			},
-    		ctx: {
-    			pt: pt
-    		}
-    	}, function() {
-   			return pt.z == 10;
-    	});
-    	bbb.always({
-			solver: new DBPlanner(),
-    		ctx: {
-    			pt: pt
-    		}
-    	}, function() {
-   			return pt.x == pt.y;
-    	});
+        bbb.always({
+            solver: new ClSimplexSolver(),
+            ctx: {
+                pt: pt
+            }
+        }, function() {
+               return pt.y == pt.z;
+        });
+        bbb.trigger({
+            callback: function() {
+                callbackCalled = true;
+            },
+            ctx: {
+                pt: pt
+            }
+        }, function() {
+               return pt.z == 10;
+        });
+        bbb.always({
+            solver: new DBPlanner(),
+            ctx: {
+                pt: pt
+            }
+        }, function() {
+               return pt.x == pt.y;
+        });
 
         pt.x = 10;
-		this.assert(callbackCalled, "callback was not called");
-	},
-	testTriggerOtherSolvers: function() {
-	    var pt = {x: 1, y: 2},
-	        pt2 = {x: 1, y: 2},
+        this.assert(callbackCalled, "callback was not called");
+    },
+    testTriggerOtherSolvers: function() {
+        var pt = {x: 1, y: 2},
+            pt2 = {x: 1, y: 2},
             callbackCalled = false,
-	        db = new DBPlanner();
+            db = new DBPlanner();
 
-    	bbb.always({
-			solver: db,
-    		ctx: {
-    			pt2: pt2
-    		}
-    	}, function() {
-   			return pt2.x == pt2.y;
-    	});
-    	bbb.trigger({
-			callback: function() {
-			    callbackCalled = true;
-			    pt2.x = 12;
-			},
-    		ctx: {
-    			pt: pt
-    		}
-    	}, function() {
-   			return pt.y == 10;
-    	});
-    	bbb.always({
-			solver: db,
-    		ctx: {
-    			pt: pt
-    		}
-    	}, function() {
-   			return pt.x == pt.y;
-    	});
+        bbb.always({
+            solver: db,
+            ctx: {
+                pt2: pt2
+            }
+        }, function() {
+               return pt2.x == pt2.y;
+        });
+        bbb.trigger({
+            callback: function() {
+                callbackCalled = true;
+                pt2.x = 12;
+            },
+            ctx: {
+                pt: pt
+            }
+        }, function() {
+               return pt.y == 10;
+        });
+        bbb.always({
+            solver: db,
+            ctx: {
+                pt: pt
+            }
+        }, function() {
+               return pt.x == pt.y;
+        });
 
         pt.x = 10;
-		this.assert(pt.x = 10, "assignment did not work, pt.x: " + pt.x);
-		this.assert(pt.y = 10, "assignment did not work, pt.y: " + pt.y);
-		this.assert(callbackCalled, "callback was not called");
-		this.assert(pt2.x = 12, "assignment did not work, pt2.x: " + pt2.x);
-		this.assert(pt2.y = 12, "assignment did not work, pt2.y: " + pt2.y);
-	},
-	testWhenTriggerNotation: function() {
-		var p = {
-			hp: 10,
-			lives: 2
-		};
-		
-		bbb.when({
-			ctx: {
-				p: p
-			}
-		}, function() {
-			return p.hp <=  0;
-		}).trigger(function() {
-			p.lives--;
-			p.hp = 10;
-		});
+        this.assert(pt.x = 10, "assignment did not work, pt.x: " + pt.x);
+        this.assert(pt.y = 10, "assignment did not work, pt.y: " + pt.y);
+        this.assert(callbackCalled, "callback was not called");
+        this.assert(pt2.x = 12, "assignment did not work, pt2.x: " + pt2.x);
+        this.assert(pt2.y = 12, "assignment did not work, pt2.y: " + pt2.y);
+    },
+    testWhenTriggerNotation: function() {
+        var p = {
+            hp: 10,
+            lives: 2
+        };
+        
+        bbb.when({
+            ctx: {
+                p: p
+            }
+        }, function() {
+            return p.hp <=  0;
+        }).trigger(function() {
+            p.lives--;
+            p.hp = 10;
+        });
 
-		this.assert(p.lives === 2, "constraint construction modified variable, p.lives: " + p.lives);
-		this.assert(p.hp === 10, "constraint construction modified variable, p.hp: " + p.hp);
+        this.assert(p.lives === 2, "constraint construction modified variable, p.lives: " + p.lives);
+        this.assert(p.hp === 10, "constraint construction modified variable, p.hp: " + p.hp);
 
-		// valid assignment
-		p.hp = -1;
-		this.assert(p.lives === 1, "callback not triggered correctly (1), p.lives: " + p.lives);
-		this.assert(p.hp === 10, "variable that initiates the trigger could not be reset in callback, p.hp: " + p.hp);
-	},
-	testWhenTriggerDelegate: function() {
-		var p = {
-			hp: 10,
-			lives: 2
-		},
-		expectedReturnObject = {},
-		actualCtx,
-		actualConstraint,
-		expectedConstraint = function() {
-			return p.hp <=  0;
-		},
-		expectedOpts = {
-			ctx: {
-				p: p
-			}
-		},
-		expectedCallback = function() {
-			p.lives--;
-			p.hp = 10;
-		};
-		
-		var bbbTrigger = bbb.trigger;
-		bbb.trigger = function mock() {
-			actualCtx = arguments[0];
-			actualConstraint = arguments[1];
-			
-			return expectedReturnObject;
-		};
-		
-		try {
-			var c = bbb
-				.when(expectedOpts, expectedConstraint)
-				.trigger(expectedCallback);
+        // valid assignment
+        p.hp = -1;
+        this.assert(p.lives === 1, "callback not triggered correctly (1), p.lives: " + p.lives);
+        this.assert(p.hp === 10, "variable that initiates the trigger could not be reset in callback, p.hp: " + p.hp);
+    },
+    testWhenTriggerDelegate: function() {
+        var p = {
+            hp: 10,
+            lives: 2
+        },
+        expectedReturnObject = {},
+        actualCtx,
+        actualConstraint,
+        expectedConstraint = function() {
+            return p.hp <=  0;
+        },
+        expectedOpts = {
+            ctx: {
+                p: p
+            }
+        },
+        expectedCallback = function() {
+            p.lives--;
+            p.hp = 10;
+        };
+        
+        var bbbTrigger = bbb.trigger;
+        bbb.trigger = function mock() {
+            actualCtx = arguments[0];
+            actualConstraint = arguments[1];
+            
+            return expectedReturnObject;
+        };
+        
+        try {
+            var c = bbb
+                .when(expectedOpts, expectedConstraint)
+                .trigger(expectedCallback);
 
-			this.assert(expectedOpts === actualCtx);
-			this.assert(expectedOpts.callback === expectedCallback);
-			this.assert(expectedConstraint === actualConstraint);
-			this.assert(expectedReturnObject === c);
-		} finally {
-			bbb.trigger = bbbTrigger;
-		}
-	}
+            this.assert(expectedOpts === actualCtx);
+            this.assert(expectedOpts.callback === expectedCallback);
+            this.assert(expectedConstraint === actualConstraint);
+            this.assert(expectedReturnObject === c);
+        } finally {
+            bbb.trigger = bbbTrigger;
+        }
+    }
 });
 
 TestCase.subclass('users.timfelgentreff.reactive.reactive_test.LayerActivationTest', {
     testLayerActivationSolver: function() {
-		// TODO: rename trigger in test for clarification
-		var the = {
-			condition: false,
-			answer: function() {
-				return 17;
-			}
-		};
+        // TODO: rename trigger in test for clarification
+        var the = {
+            condition: false,
+            answer: function() {
+                return 17;
+            }
+        };
 
-		cop.create("correction")
-			.refineObject(the, {
-				answer: function() {
-				var oldAnswer = cop.proceed();
-					return oldAnswer + 25;
-				}
-			})
-			.activeOn({
-				ctx: {
-					the: the
-				}
-			}, function() {
-				return the.condition === true;
-			});
+        cop.create("correction")
+            .refineObject(the, {
+                answer: function() {
+                var oldAnswer = cop.proceed();
+                    return oldAnswer + 25;
+                }
+            })
+            .activeOn({
+                ctx: {
+                    the: the
+                }
+            }, function() {
+                return the.condition === true;
+            });
 
-		this.assert(the.answer() === 17, "not the correct answer, but " + the.answer());
-		
-		the.condition = true;
-		this.assert(the.answer() === 42, "layer not correctly activated, the.answer(): " + the.answer());
-		
-		the.condition = false;
-		this.assert(the.answer() === 17, "layer not correctly de-activated, the.answer(): " + the.answer());
-	},
-	// TODO
+        this.assert(the.answer() === 17, "not the correct answer, but " + the.answer());
+        
+        the.condition = true;
+        this.assert(the.answer() === 42, "layer not correctly activated, the.answer(): " + the.answer());
+        
+        the.condition = false;
+        this.assert(the.answer() === 17, "layer not correctly de-activated, the.answer(): " + the.answer());
+    },
+    // TODO
     testImmediateTriggerOnAvtivationDefinition: function() {
-	}
+    }
 });
 
 TestCase.subclass('users.timfelgentreff.reactive.reactive_test.ScopedConstraintsTest', {
     testScopedConstraints: function() {
-		var temperature = {
-			celsius: 0,
-			fahrenheit: 0
-		};
+        var temperature = {
+            celsius: 0,
+            fahrenheit: 0
+        };
 
-		cop.create("synchronization3")
-			.always({
-				solver: new ClSimplexSolver(),
-				ctx: {
-					temperature: temperature
-				}
-			}, function() {
-				return temperature.celsius * 1.8 == temperature.fahrenheit - 32;
-			});
-		this.assert(temperature.celsius === 0, "attributes changed without modification; temperature.celsius: " + temperature.celsius);
-		this.assert(temperature.fahrenheit === 0, "attributes changed without modification; temperature.fahrenheit: " + temperature.fahrenheit);
-		
-		// unconstrained assignment
-		temperature.celsius = 17;
-		this.assert(temperature.celsius === 17, "assignment did not work; temperature.celsius: " + temperature.celsius);
-		this.assert(temperature.fahrenheit === 0, "value changed although no constraint was enabled; temperature.fahrenheit: " + temperature.fahrenheit);
-		
-		// layer activation
-		synchronization3.beGlobal();
-		this.assert(temperature.celsius * 1.8 == temperature.fahrenheit - 32, "constraint was not solved after layer activation; temperature.celsius: " + temperature.celsius + ", temperature.fahrenheit: " + temperature.fahrenheit);
-		
-		// constrained assignment
-		temperature.celsius = 20;
-		this.assert(temperature.celsius * 1.8 == temperature.fahrenheit - 32, "constraint is not fulfilled after constrained assignment; temperature.celsius: " + temperature.celsius + ", temperature.fahrenheit: " + temperature.fahrenheit);
-		this.assert(temperature.celsius === 20, "assignment did not work; temperature.celsius: " + temperature.celsius);
+        cop.create("synchronization3")
+            .always({
+                solver: new ClSimplexSolver(),
+                ctx: {
+                    temperature: temperature
+                }
+            }, function() {
+                return temperature.celsius * 1.8 == temperature.fahrenheit - 32;
+            });
+        this.assert(temperature.celsius === 0, "attributes changed without modification; temperature.celsius: " + temperature.celsius);
+        this.assert(temperature.fahrenheit === 0, "attributes changed without modification; temperature.fahrenheit: " + temperature.fahrenheit);
+        
+        // unconstrained assignment
+        temperature.celsius = 17;
+        this.assert(temperature.celsius === 17, "assignment did not work; temperature.celsius: " + temperature.celsius);
+        this.assert(temperature.fahrenheit === 0, "value changed although no constraint was enabled; temperature.fahrenheit: " + temperature.fahrenheit);
+        
+        // layer activation
+        synchronization3.beGlobal();
+        this.assert(temperature.celsius * 1.8 == temperature.fahrenheit - 32, "constraint was not solved after layer activation; temperature.celsius: " + temperature.celsius + ", temperature.fahrenheit: " + temperature.fahrenheit);
+        
+        // constrained assignment
+        temperature.celsius = 20;
+        this.assert(temperature.celsius * 1.8 == temperature.fahrenheit - 32, "constraint is not fulfilled after constrained assignment; temperature.celsius: " + temperature.celsius + ", temperature.fahrenheit: " + temperature.fahrenheit);
+        this.assert(temperature.celsius === 20, "assignment did not work; temperature.celsius: " + temperature.celsius);
 
-		var prevCelsius = temperature.celsius;
-		var prevFahrenheit = temperature.fahrenheit;
-		
-		// layer deactivation
-		synchronization3.beNotGlobal();
-		this.assert(temperature.celsius * 1.8 == temperature.fahrenheit - 32, "constraint was not solved after layer activation; temperature.celsius: " + temperature.celsius + ", temperature.fahrenheit: " + temperature.fahrenheit);
-		this.assert(temperature.celsius === prevCelsius, "value changed during layer de-activation; temperature.celsius: " + temperature.celsius + ", previous value: " + prevCelsius);
-		this.assert(temperature.fahrenheit === prevFahrenheit, "value changed during layer de-activation; temperature.fahrenheit: " + temperature.fahrenheit + ", previous value: " + prevFahrenheit);
+        var prevCelsius = temperature.celsius;
+        var prevFahrenheit = temperature.fahrenheit;
+        
+        // layer deactivation
+        synchronization3.beNotGlobal();
+        this.assert(temperature.celsius * 1.8 == temperature.fahrenheit - 32, "constraint was not solved after layer activation; temperature.celsius: " + temperature.celsius + ", temperature.fahrenheit: " + temperature.fahrenheit);
+        this.assert(temperature.celsius === prevCelsius, "value changed during layer de-activation; temperature.celsius: " + temperature.celsius + ", previous value: " + prevCelsius);
+        this.assert(temperature.fahrenheit === prevFahrenheit, "value changed during layer de-activation; temperature.fahrenheit: " + temperature.fahrenheit + ", previous value: " + prevFahrenheit);
 
-		// unconstrained assignment
-		temperature.celsius = 42;
-		this.assert(temperature.celsius === 42, "assignment did not work; temperature.celsius: " + temperature.celsius);
-		this.assert(temperature.fahrenheit === prevFahrenheit, "value of unassigned variable changed; temperature.fahrenheit: " + temperature.fahrenheit);
-	},
+        // unconstrained assignment
+        temperature.celsius = 42;
+        this.assert(temperature.celsius === 42, "assignment did not work; temperature.celsius: " + temperature.celsius);
+        this.assert(temperature.fahrenheit === prevFahrenheit, "value of unassigned variable changed; temperature.fahrenheit: " + temperature.fahrenheit);
+    },
     testWithLayers: function() {
-		var prevFahrenheit, temperature = {
-			celsius: 0,
-			fahrenheit: 0
-		};
+        var prevFahrenheit, temperature = {
+            celsius: 0,
+            fahrenheit: 0
+        };
 
-		cop.create("synchronization1")
-			.always({
-				solver: new ClSimplexSolver(),
-				ctx: {
-					temperature: temperature
-				}
-			}, function() {
-				return temperature.celsius * 1.8 == temperature.fahrenheit - 32;
-			});
-		
-		var testcase = this;
-		cop.withLayers([synchronization1], function() {
-			testcase.assert(temperature.celsius * 1.8 == temperature.fahrenheit - 32, "constraint was not solved after layer activation; temperature.celsius: " + temperature.celsius + ", temperature.fahrenheit: " + temperature.fahrenheit);
+        cop.create("synchronization1")
+            .always({
+                solver: new ClSimplexSolver(),
+                ctx: {
+                    temperature: temperature
+                }
+            }, function() {
+                return temperature.celsius * 1.8 == temperature.fahrenheit - 32;
+            });
+        
+        var testcase = this;
+        cop.withLayers([synchronization1], function() {
+            testcase.assert(temperature.celsius * 1.8 == temperature.fahrenheit - 32, "constraint was not solved after layer activation; temperature.celsius: " + temperature.celsius + ", temperature.fahrenheit: " + temperature.fahrenheit);
 
-			// constrained assignment
-			temperature.celsius = 20;
-			testcase.assert(temperature.celsius * 1.8 == temperature.fahrenheit - 32, "constraint is not fulfilled after constrained assignment; temperature.celsius: " + temperature.celsius + ", temperature.fahrenheit: " + temperature.fahrenheit);
-			testcase.assert(temperature.celsius === 20, "assignment did not work; temperature.celsius: " + temperature.celsius);
+            // constrained assignment
+            temperature.celsius = 20;
+            testcase.assert(temperature.celsius * 1.8 == temperature.fahrenheit - 32, "constraint is not fulfilled after constrained assignment; temperature.celsius: " + temperature.celsius + ", temperature.fahrenheit: " + temperature.fahrenheit);
+            testcase.assert(temperature.celsius === 20, "assignment did not work; temperature.celsius: " + temperature.celsius);
 
-			prevFahrenheit = temperature.fahrenheit;
-		});
-		
-		// unconstrained assignment
-		temperature.celsius = 42;
-		this.assert(temperature.celsius === 42, "assignment did not work; temperature.celsius: " + temperature.celsius);
-		this.assert(temperature.fahrenheit === prevFahrenheit, "value of unassigned variable changed; temperature.fahrenheit: " + temperature.fahrenheit);
-	},
+            prevFahrenheit = temperature.fahrenheit;
+        });
+        
+        // unconstrained assignment
+        temperature.celsius = 42;
+        this.assert(temperature.celsius === 42, "assignment did not work; temperature.celsius: " + temperature.celsius);
+        this.assert(temperature.fahrenheit === prevFahrenheit, "value of unassigned variable changed; temperature.fahrenheit: " + temperature.fahrenheit);
+    },
     testAlwaysWithAlreadyActivatedLayer: function() {
-		var prevFahrenheit, temperature = {
-			celsius: 10,
-			fahrenheit: 0
-		};
+        var prevFahrenheit, temperature = {
+            celsius: 10,
+            fahrenheit: 0
+        };
 
-		cop.create("synchronization2")
-			.activeOn({
-				ctx: {
-					temperature: temperature
-				}
-			}, function() {
-				return temperature.celsius >= 5;
-			})
-			.always({
-				solver: new ClSimplexSolver(),
-				ctx: {
-					temperature: temperature
-				}
-			}, function() {
-				return temperature.celsius * 1.8 == temperature.fahrenheit - 32;
-			});
-		this.assert(temperature.celsius * 1.8 == temperature.fahrenheit - 32, "constraint was not solved after layer activation; temperature.celsius: " + temperature.celsius + ", temperature.fahrenheit: " + temperature.fahrenheit);
-		
-		// unconstrained assignment
-		temperature.celsius = 42;
-		this.assert(temperature.celsius === 42, "assignment did not work; temperature.celsius: " + temperature.celsius);
-		// TODO: check constraint
-	},
+        cop.create("synchronization2")
+            .activeOn({
+                ctx: {
+                    temperature: temperature
+                }
+            }, function() {
+                return temperature.celsius >= 5;
+            })
+            .always({
+                solver: new ClSimplexSolver(),
+                ctx: {
+                    temperature: temperature
+                }
+            }, function() {
+                return temperature.celsius * 1.8 == temperature.fahrenheit - 32;
+            });
+        this.assert(temperature.celsius * 1.8 == temperature.fahrenheit - 32, "constraint was not solved after layer activation; temperature.celsius: " + temperature.celsius + ", temperature.fahrenheit: " + temperature.fahrenheit);
+        
+        // unconstrained assignment
+        temperature.celsius = 42;
+        this.assert(temperature.celsius === 42, "assignment did not work; temperature.celsius: " + temperature.celsius);
+        // TODO: check constraint
+    },
     testScopedAssert: function() {
-		var temperature = {
-			celsius: 10,
-			sense: false
-		};
+        var temperature = {
+            celsius: 10,
+            sense: false
+        };
 
-		cop.create("thermometer")
-			.activeOn({
-				ctx: {
-					temperature: temperature
-				}
-			}, function() {
-				return temperature.sense === true;
-			})
-			.assert({
-				ctx: {
-					temperature: temperature
-				}
-			}, function() {
-				return temperature.celsius > -273;
-			});
-		
-		temperature.celsius = -1000;
-		temperature.celsius = 10;
-		
-		temperature.sense = true
-		new users.timfelgentreff.reactive.reactive_test.AssertTest().assertWithError(
-			ContinuousAssertError,
-			function() {
-				temperature.celsius = -1000;
-			},
-			"no ContinuousAssertError was thrown"
-		);
-		this.assert(temperature.celsius === 10, "revert did not work; temperature.celsius: " + temperature.celsius);
-	},
+        cop.create("thermometer")
+            .activeOn({
+                ctx: {
+                    temperature: temperature
+                }
+            }, function() {
+                return temperature.sense === true;
+            })
+            .assert({
+                ctx: {
+                    temperature: temperature
+                }
+            }, function() {
+                return temperature.celsius > -273;
+            });
+        
+        temperature.celsius = -1000;
+        temperature.celsius = 10;
+        
+        temperature.sense = true
+        new users.timfelgentreff.reactive.reactive_test.AssertTest().assertWithError(
+            ContinuousAssertError,
+            function() {
+                temperature.celsius = -1000;
+            },
+            "no ContinuousAssertError was thrown"
+        );
+        this.assert(temperature.celsius === 10, "revert did not work; temperature.celsius: " + temperature.celsius);
+    },
     testScopedAssertBreaksImmediatly: function() {
-		var temperature = {
-			celsius: -1000,
-			sense: false
-		};
+        var temperature = {
+            celsius: -1000,
+            sense: false
+        };
 
-		cop.create("thermometer")
-			.activeOn({
-				ctx: {
-					temperature: temperature
-				}
-			}, function() {
-				return temperature.sense === true;
-			})
-			.assert({
-				ctx: {
-					temperature: temperature
-				}
-			}, function() {
-				return temperature.celsius > -273;
-			});
-		
-		temperature.celsius = -1000;
-		
-		new users.timfelgentreff.reactive.reactive_test.AssertTest().assertWithError(
-			ContinuousAssertError,
-			function() {
-				// trigger that activates an immediately breaking assertion
-				temperature.sense = true
-			},
-			"no ContinuousAssertError was thrown"
-		);
-	},
+        cop.create("thermometer")
+            .activeOn({
+                ctx: {
+                    temperature: temperature
+                }
+            }, function() {
+                return temperature.sense === true;
+            })
+            .assert({
+                ctx: {
+                    temperature: temperature
+                }
+            }, function() {
+                return temperature.celsius > -273;
+            });
+        
+        temperature.celsius = -1000;
+        
+        new users.timfelgentreff.reactive.reactive_test.AssertTest().assertWithError(
+            ContinuousAssertError,
+            function() {
+                // trigger that activates an immediately breaking assertion
+                temperature.sense = true
+            },
+            "no ContinuousAssertError was thrown"
+        );
+    },
     testScopedTrigger: function() {
-		var count = 0, obj = {
-			activated: false,
-			trigger: false,
-			action: function() {
-				count++;
-			}
-		};
-    	
-		cop.create("triggerLayer")
-			.activeOn({
-				ctx: {
-					obj: obj
-				}
-			}, function() {
-				return obj.activated === true;
-			})
-			.trigger({
-				callback: obj.action.bind(obj),
-				ctx: {
-					obj: obj
-				}
-			}, function() {
-				return obj.trigger === true;
-			});
-		this.assert(count === 0, "action was already triggered, count: " + count);
-		this.assert(obj.activated === false, "layer was unintentionally activated");
-		this.assert(obj.trigger === false, "trigger variable was changed");
+        var count = 0, obj = {
+            activated: false,
+            trigger: false,
+            action: function() {
+                count++;
+            }
+        };
+        
+        cop.create("triggerLayer")
+            .activeOn({
+                ctx: {
+                    obj: obj
+                }
+            }, function() {
+                return obj.activated === true;
+            })
+            .trigger({
+                callback: obj.action.bind(obj),
+                ctx: {
+                    obj: obj
+                }
+            }, function() {
+                return obj.trigger === true;
+            });
+        this.assert(count === 0, "action was already triggered, count: " + count);
+        this.assert(obj.activated === false, "layer was unintentionally activated");
+        this.assert(obj.trigger === false, "trigger variable was changed");
 
-		// unactivated trigger
-		obj.trigger = true;
-		this.assert(count === 0, "action was already triggered, count: " + count);
-		this.assert(obj.activated === false, "layer was unintentionally activated");
-		this.assert(obj.trigger === true, "assignment did not work");
-		
-		// reset trigger
-		obj.trigger = false;
-		this.assert(count === 0, "action was already triggered, count: " + count);
-		this.assert(obj.activated === false, "layer was unintentionally activated");
-		this.assert(obj.trigger === false, "assignment did not work");
+        // unactivated trigger
+        obj.trigger = true;
+        this.assert(count === 0, "action was already triggered, count: " + count);
+        this.assert(obj.activated === false, "layer was unintentionally activated");
+        this.assert(obj.trigger === true, "assignment did not work");
+        
+        // reset trigger
+        obj.trigger = false;
+        this.assert(count === 0, "action was already triggered, count: " + count);
+        this.assert(obj.activated === false, "layer was unintentionally activated");
+        this.assert(obj.trigger === false, "assignment did not work");
 
-		// activate layer
-		obj.activated = true;
-		this.assert(count === 0, "action was already triggered, count: " + count);
-		this.assert(obj.activated === true, "assignment did not work");
-		this.assert(obj.trigger === false, "trigger unintentionally initiated");
-		this.assert(triggerLayer.isGlobal(), "layer not active");
+        // activate layer
+        obj.activated = true;
+        this.assert(count === 0, "action was already triggered, count: " + count);
+        this.assert(obj.activated === true, "assignment did not work");
+        this.assert(obj.trigger === false, "trigger unintentionally initiated");
+        this.assert(triggerLayer.isGlobal(), "layer not active");
 
-		// activated triggering
-		obj.trigger = true;
-		this.assert(count === 1, "action not triggered once, count: " + count);
-		this.assert(obj.activated === true, "modified unassigned variables");
-		this.assert(obj.trigger === true, "assignment did not work");
-		this.assert(triggerLayer.isGlobal(), "layer not active");
-	}
+        // activated triggering
+        obj.trigger = true;
+        this.assert(count === 1, "action not triggered once, count: " + count);
+        this.assert(obj.activated === true, "modified unassigned variables");
+        this.assert(obj.trigger === true, "assignment did not work");
+        this.assert(triggerLayer.isGlobal(), "layer not active");
+    }
 });
 
 }); // end of module

--- a/standalone/examples/csp/Intersection.js
+++ b/standalone/examples/csp/Intersection.js
@@ -1,95 +1,95 @@
 var Intersection = {
-	intersectLineLine: function(a1, a2, b1, b2) {
-	    var ua_t = (b2[0] - b1[0]) * (a1[1] - b1[1]) - (b2[1] - b1[1]) * (a1[0] - b1[0]);
-	    var ub_t = (a2[0] - a1[0]) * (a1[1] - b1[1]) - (a2[1] - a1[1]) * (a1[0] - b1[0]);
-	    var u_b  = (b2[1] - b1[1]) * (a2[0] - a1[0]) - (b2[0] - b1[0]) * (a2[1] - a1[1]);
-	
-	    if ( u_b != 0 ) {
-	        var ua = ua_t / u_b;
-	        var ub = ub_t / u_b;
-	
-	        if ( 0 <= ua && ua <= 1 && 0 <= ub && ub <= 1 ) {
-	            return true;
-	        }
-	    }
-	    return false;
-	},
-	
-	intersectLinePolygon: function(a1, a2, points) {
-	    var length = points.length;
-	
-	    for ( var i = 0; i < length; i++ ) {
-	        var b1 = points[i];
-	        var b2 = points[(i+1) % length];
-	        if(Intersection.intersectLineLine(a1, a2, b1, b2)) return true;
-	    }
-	
-	    return false;
-	},
-	
-	intersectPolygonPolygon: function(points1, points2) {
-	    var length = points1.length;
-	
-	    for ( var i = 0; i < length; i++ ) {
-	        var a1 = points1[i];
-	        var a2 = points1[(i+1) % length];
-	        if(Intersection.intersectLinePolygon(a1, a2, points2)) return true;
-	    }
-	
-	    return false;
-	},
-	
-	intersectAABB: function(aabb1, aabb2) {
-		return !(
-			aabb1.min[0] > aabb2.max[0] ||
-			aabb1.min[1] > aabb2.max[1] ||
-			aabb1.max[0] < aabb2.min[0] ||
-			aabb1.max[1] < aabb2.min[1]);
-	},
-	
-	intersectGeometry: function(geometry1, geometry2) {
-		var intersects = _.some(geometry1.coordinates, function(coords1, index1) {
-			return _.some(geometry2.coordinates, function(coords2, index2) {
-				return Intersection.intersectAABB(geometry1.aabbs[index1], geometry2.aabbs[index2]) &&
-					Intersection.intersectPolygonPolygon(coords1, coords2);
-			}, this);
-		}, this);
-		
-		return intersects;
-	},
-	
-	intersectStates: function(state1, state2) {
-		return Intersection.intersectGeometry(state1.geometry, state2.geometry);
-	}
+    intersectLineLine: function(a1, a2, b1, b2) {
+        var ua_t = (b2[0] - b1[0]) * (a1[1] - b1[1]) - (b2[1] - b1[1]) * (a1[0] - b1[0]);
+        var ub_t = (a2[0] - a1[0]) * (a1[1] - b1[1]) - (a2[1] - a1[1]) * (a1[0] - b1[0]);
+        var u_b  = (b2[1] - b1[1]) * (a2[0] - a1[0]) - (b2[0] - b1[0]) * (a2[1] - a1[1]);
+    
+        if ( u_b != 0 ) {
+            var ua = ua_t / u_b;
+            var ub = ub_t / u_b;
+    
+            if ( 0 <= ua && ua <= 1 && 0 <= ub && ub <= 1 ) {
+                return true;
+            }
+        }
+        return false;
+    },
+    
+    intersectLinePolygon: function(a1, a2, points) {
+        var length = points.length;
+    
+        for ( var i = 0; i < length; i++ ) {
+            var b1 = points[i];
+            var b2 = points[(i+1) % length];
+            if(Intersection.intersectLineLine(a1, a2, b1, b2)) return true;
+        }
+    
+        return false;
+    },
+    
+    intersectPolygonPolygon: function(points1, points2) {
+        var length = points1.length;
+    
+        for ( var i = 0; i < length; i++ ) {
+            var a1 = points1[i];
+            var a2 = points1[(i+1) % length];
+            if(Intersection.intersectLinePolygon(a1, a2, points2)) return true;
+        }
+    
+        return false;
+    },
+    
+    intersectAABB: function(aabb1, aabb2) {
+        return !(
+            aabb1.min[0] > aabb2.max[0] ||
+            aabb1.min[1] > aabb2.max[1] ||
+            aabb1.max[0] < aabb2.min[0] ||
+            aabb1.max[1] < aabb2.min[1]);
+    },
+    
+    intersectGeometry: function(geometry1, geometry2) {
+        var intersects = _.some(geometry1.coordinates, function(coords1, index1) {
+            return _.some(geometry2.coordinates, function(coords2, index2) {
+                return Intersection.intersectAABB(geometry1.aabbs[index1], geometry2.aabbs[index2]) &&
+                    Intersection.intersectPolygonPolygon(coords1, coords2);
+            }, this);
+        }, this);
+        
+        return intersects;
+    },
+    
+    intersectStates: function(state1, state2) {
+        return Intersection.intersectGeometry(state1.geometry, state2.geometry);
+    }
 };
 
 //bounding boxes
 var AABB = function(min, max) {
-	this.min = min;
-	this.max = max;
+    this.min = min;
+    this.max = max;
 };
 
 AABB.fromPath = function(path) {
-	var min = [10000, 10000],
-		max = [-10000, -10000];
-	
-	_.each(path, function(point) {
-		if(min[0] > point[0]) min[0] = point[0];
-		if(min[1] > point[1]) min[1] = point[1];
-		if(max[0] < point[0]) max[0] = point[0];
-		if(max[1] < point[1]) max[1] = point[1];
-	});
-	
-	return new AABB(min, max);
+    var min = [10000, 10000],
+        max = [-10000, -10000];
+    
+    _.each(path, function(point) {
+        if(min[0] > point[0]) min[0] = point[0];
+        if(min[1] > point[1]) min[1] = point[1];
+        if(max[0] < point[0]) max[0] = point[0];
+        if(max[1] < point[1]) max[1] = point[1];
+    });
+    
+    return new AABB(min, max);
 };
 
 AABB.prototype.combine = function(aabb2) {
-	return new AABB([
-	    this.min[0] < aabb2.min[0] ? this.min[0] : aabb2.min[0],
-	    this.min[1] < aabb2.min[1] ? this.min[1] : aabb2.min[1]
-	    ],
-	    [
-	    this.max[0] > aabb2.max[0] ? this.max[0] : aabb2.max[0],
-	    this.max[1] > aabb2.max[1] ? this.max[1] : aabb2.max[1]
-	    ]);
+    return new AABB([
+        this.min[0] < aabb2.min[0] ? this.min[0] : aabb2.min[0],
+        this.min[1] < aabb2.min[1] ? this.min[1] : aabb2.min[1]
+        ],
+        [
+        this.max[0] > aabb2.max[0] ? this.max[0] : aabb2.max[0],
+        this.max[1] > aabb2.max[1] ? this.max[1] : aabb2.max[1]
+        ]);
 };

--- a/standalone/examples/domconstraints/domconstraints.js
+++ b/standalone/examples/domconstraints/domconstraints.js
@@ -1,23 +1,23 @@
 contentLoaded(window, function() {
-	cas = new ClSimplexSolver();
-	var deltablue = new DBPlanner();
+    cas = new ClSimplexSolver();
+    var deltablue = new DBPlanner();
 
-	var div = document.getElementById("div1");
-	console.log(div, div.style.width , div.style.height);
+    var div = document.getElementById("div1");
+    console.log(div, div.style.width , div.style.height);
 
-	bbb.always({
-	    solver: deltablue,
-	    ctx: {
-	        style: div.style,
-	        _$_self: this.doitContext || this
-	    }
-	}, function() {
-		style.width.formula([ style.height ], function(height) {
-	        return height;
-	    });
-	    return style.height.formula([ style.width ], function(width) {
-	        return width;
-	    });;
-	});
+    bbb.always({
+        solver: deltablue,
+        ctx: {
+            style: div.style,
+            _$_self: this.doitContext || this
+        }
+    }, function() {
+        style.width.formula([ style.height ], function(height) {
+            return height;
+        });
+        return style.height.formula([ style.width ], function(width) {
+            return width;
+        });;
+    });
 });
 

--- a/standalone/examples/dress code/dress code.js
+++ b/standalone/examples/dress code/dress code.js
@@ -1,13 +1,13 @@
 contentLoaded(window, function() {
-	var colors = ["blue", "black", "brown", "white"];
-	var man = {
-		shoes: "brown",
-		shirt: "brown",
-		pants: "brown",
-		hat: "brown"	
-	};
+    var colors = ["blue", "black", "brown", "white"];
+    var man = {
+        shoes: "brown",
+        shirt: "brown",
+        pants: "brown",
+        hat: "brown"    
+    };
     var solver = bbb.defaultSolver = new csp.Solver();
-	
+    
     always: { man.shoes.is in ["brown", "black"] }
     always: { man.shirt.is in ["blue", "white", "brown"] }
     always: { man.pants.is in ["blue", "black", "brown", "white"] }

--- a/standalone/examples/robot/lib/world/gameobject.js
+++ b/standalone/examples/robot/lib/world/gameobject.js
@@ -1,51 +1,51 @@
 Object.subclass("GameObject", {
-	initialize: function(world, name, pos, extent, radius) {
-	    this.world = world;
-		this.name = name;
+    initialize: function(world, name, pos, extent, radius) {
+        this.world = world;
+        this.name = name;
 
-		this.position = pos;
+        this.position = pos;
         this.prevPosition = pos.copy();
-		this.coordinates = Vector2.Zero.copy().sub(new Vector2(-1,-1));
-		this.collisionTiles = {
-    		upperLeft:false,
-    		bottomLeft:true,
-    		upperRight:true,
-    		bottomRight:true
-		};
+        this.coordinates = Vector2.Zero.copy().sub(new Vector2(-1,-1));
+        this.collisionTiles = {
+            upperLeft:false,
+            bottomLeft:true,
+            upperRight:true,
+            bottomRight:true
+        };
 
         this.velocity = Vector2.Zero.copy();
 
-		this.radius = 5;
-		this.extent = extent;
-		this.speed = 3;
-	},
+        this.radius = 5;
+        this.extent = extent;
+        this.speed = 3;
+    },
 
-	update: function(dt) {
-	    this.prevPosition.set(this.position);
+    update: function(dt) {
+        this.prevPosition.set(this.position);
 
         var deltaPos = this.velocity.normalizedCopy().mulFloat(dt*this.speed);
         this.position.addSelf(deltaPos);
 
         if(typeof this.animation !== "undefined")
             this.animation.update(dt);
-	},
-	
-	draw: function(renderer) {
-		if(typeof this.animation !== "undefined") {
-			var halfSize = this.extent.divFloat(2);
-			var aabb = new AABB(
-				this.position.sub(halfSize),
-				this.position.add(halfSize)
-			);
-			this.animation.draw(renderer, aabb);
-		}
+    },
+    
+    draw: function(renderer) {
+        if(typeof this.animation !== "undefined") {
+            var halfSize = this.extent.divFloat(2);
+            var aabb = new AABB(
+                this.position.sub(halfSize),
+                this.position.add(halfSize)
+            );
+            this.animation.draw(renderer, aabb);
+        }
 
-		renderer.drawLine(this.position, this.position.add(this.velocity.mulFloat(5)), "red", 1, 3);
-	},
+        renderer.drawLine(this.position, this.position.add(this.velocity.mulFloat(5)), "red", 1, 3);
+    },
 
-	getTile: function(pos) {
-	    return this.world.map.get(this.world.map.positionToCoordinates(pos));
-	}
+    getTile: function(pos) {
+        return this.world.map.get(this.world.map.positionToCoordinates(pos));
+    }
 });
 
 // possible constraints:
@@ -54,13 +54,13 @@ Object.subclass("GameObject", {
 // - your speed is limited to maxSpeed (cannot adjust speed?)
 // - your velocity is direction.mulFloat(dt*speed)
 GameObject.subclass("Tank", {
-	initialize: function($super, world, pos) {
-	    $super(world, "tank", pos, new Vector2(2, 2), 1);
+    initialize: function($super, world, pos) {
+        $super(world, "tank", pos, new Vector2(2, 2), 1);
 
-		this.animation = new Animation(new AnimationSheet("assets/tank.png", 18, 18), 0.4, [0,1,2,3]);
-		this.speed = 16 / 6 * world.map.tileSize.x;
+        this.animation = new Animation(new AnimationSheet("assets/tank.png", 18, 18), 0.4, [0,1,2,3]);
+        this.speed = 16 / 6 * world.map.tileSize.x;
 
-		this.initConstraints(world);
+        this.initConstraints(world);
     },
     initConstraints: function(world) {
         var that = this,
@@ -139,14 +139,14 @@ GameObject.subclass("Tank", {
                    ((that.collisionTiles).bottomRight).index  == 0;
         });
         */
-	}
+    }
 });
 
 Tank.subclass("PlayerTank", {
-	initialize: function($super, world, pos) {
-	    $super(world, pos);
+    initialize: function($super, world, pos) {
+        $super(world, pos);
 
-		this.animation = new Animation(new AnimationSheet("assets/tank.png", 18, 18), 0.4, [0,1,2,3]);
+        this.animation = new Animation(new AnimationSheet("assets/tank.png", 18, 18), 0.4, [0,1,2,3]);
     }
 });
 
@@ -154,36 +154,36 @@ Tank.subclass("CPUTank", {
     initialize: function($super, world, pos) {
         $super(world, pos);
 
-		this.animation = new Animation(new AnimationSheet("assets/tank.png", 18, 18), 0.4, [4,5,6,7]);
+        this.animation = new Animation(new AnimationSheet("assets/tank.png", 18, 18), 0.4, [4,5,6,7]);
 
         // immobilize for now
         this.velocity.set(new Vector2(-1,1));
     },
 
-	update: function($super, dt) {
-	    // adjust direction randomly
-	    this.velocity.rotateSelf(Math.PI / 180 * (Math.random() - 0.5) * 50);
+    update: function($super, dt) {
+        // adjust direction randomly
+        this.velocity.rotateSelf(Math.PI / 180 * (Math.random() - 0.5) * 50);
 
-	    $super(dt);
-	}
+        $super(dt);
+    }
 });
 
 GameObject.subclass("Bullet", {
-	initialize: function($super, world, pos, vel, maxReflections) {
-	    $super(world, "bullet", pos, new Vector2(0.5, 0.5), 0.25);
+    initialize: function($super, world, pos, vel, maxReflections) {
+        $super(world, "bullet", pos, new Vector2(0.5, 0.5), 0.25);
 
         this.velocity.set(vel);
-		this.animation = new Animation(new AnimationSheet("assets/bullet.png", 7, 7), 0.2, [0,1,2,3,2,1]);
+        this.animation = new Animation(new AnimationSheet("assets/bullet.png", 7, 7), 0.2, [0,1,2,3,2,1]);
 
         this.maxReflections = maxReflections || 2;
         this.reflectionCount = 0;
 
-   		this.speed = 16 / 3.7 * world.map.tileSize.x;
+           this.speed = 16 / 3.7 * world.map.tileSize.x;
 
-		this.initConstraints(world);
-	},
+        this.initConstraints(world);
+    },
 
-	initConstraints: function(world) {
+    initConstraints: function(world) {
         var that = this,
             map = this.world.map,
             db = new DBPlanner();
@@ -245,5 +245,5 @@ GameObject.subclass("Bullet", {
             return that.position.divVector(world.map.tileSize).floor().equals(that.coordinates);
         });
         */
-	}
+    }
 });

--- a/standalone/examples/robot/lib/world/world.js
+++ b/standalone/examples/robot/lib/world/world.js
@@ -1,66 +1,66 @@
 Object.subclass("World", {
-	initialize: function(boundary) {
-		this.boundary = boundary;
-		this.gameObjects = [];
-		this.map = new Map(new Vector2(2,2),
-		[[1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1],
-		 [1,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,1],
-		 [1,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,1],
-		 [1,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,1],
-		 [1,0,0,0,0,0,0,0,0,1,0,0,0,0,1,0,0,0,0,0,0,0,0,1],
-		 [1,0,0,0,0,0,0,0,0,1,0,0,0,0,1,0,0,0,0,0,0,0,0,1],
-		 [1,0,0,0,0,0,0,0,0,2,0,0,0,0,2,0,0,0,0,0,0,0,0,1],
-		 [1,0,0,0,0,1,1,1,2,2,0,0,0,0,2,2,1,1,1,1,1,1,1,1],
-		 [1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1],
-		 [1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1],
-		 [1,1,1,1,1,1,1,1,2,2,0,0,0,0,2,2,1,1,1,0,0,0,0,1],
-		 [1,0,0,0,0,0,0,0,0,2,0,0,0,0,2,0,0,0,0,0,0,0,0,1],
-		 [1,0,0,0,0,0,0,0,0,1,0,0,0,0,1,0,0,0,0,0,0,0,0,1],
-		 [1,0,0,0,0,0,0,0,0,1,0,0,0,0,1,0,0,0,0,0,0,0,0,1],
-		 [1,0,0,0,0,0,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,1],
-		 [1,0,0,0,0,0,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,1],
-		 [1,0,0,0,0,0,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,1],
-		 [1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1]]
-		);
-	},
-	
-	update: function(dt) {
-		var objectCount = this.gameObjects.length;
-		for(var i = 0; i < objectCount; i++) {
-			this.gameObjects[i].update(dt);
-		}
-	},
-	
-	draw: function(renderer) {
-		this.map.draw(renderer);
+    initialize: function(boundary) {
+        this.boundary = boundary;
+        this.gameObjects = [];
+        this.map = new Map(new Vector2(2,2),
+        [[1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1],
+         [1,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,1],
+         [1,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,1],
+         [1,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,1],
+         [1,0,0,0,0,0,0,0,0,1,0,0,0,0,1,0,0,0,0,0,0,0,0,1],
+         [1,0,0,0,0,0,0,0,0,1,0,0,0,0,1,0,0,0,0,0,0,0,0,1],
+         [1,0,0,0,0,0,0,0,0,2,0,0,0,0,2,0,0,0,0,0,0,0,0,1],
+         [1,0,0,0,0,1,1,1,2,2,0,0,0,0,2,2,1,1,1,1,1,1,1,1],
+         [1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1],
+         [1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1],
+         [1,1,1,1,1,1,1,1,2,2,0,0,0,0,2,2,1,1,1,0,0,0,0,1],
+         [1,0,0,0,0,0,0,0,0,2,0,0,0,0,2,0,0,0,0,0,0,0,0,1],
+         [1,0,0,0,0,0,0,0,0,1,0,0,0,0,1,0,0,0,0,0,0,0,0,1],
+         [1,0,0,0,0,0,0,0,0,1,0,0,0,0,1,0,0,0,0,0,0,0,0,1],
+         [1,0,0,0,0,0,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,1],
+         [1,0,0,0,0,0,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,1],
+         [1,0,0,0,0,0,0,0,0,0,0,0,0,0,1,0,0,0,0,0,0,0,0,1],
+         [1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1]]
+        );
+    },
+    
+    update: function(dt) {
+        var objectCount = this.gameObjects.length;
+        for(var i = 0; i < objectCount; i++) {
+            this.gameObjects[i].update(dt);
+        }
+    },
+    
+    draw: function(renderer) {
+        this.map.draw(renderer);
 
-		var objectCount = this.gameObjects.length;
-		for(var i = 0; i < objectCount; i++) {
-			this.gameObjects[i].draw(renderer);
-		}
-	},
+        var objectCount = this.gameObjects.length;
+        for(var i = 0; i < objectCount; i++) {
+            this.gameObjects[i].draw(renderer);
+        }
+    },
 
-	/*
-	 * Manage GameObjects
-	 */
-	spawn: function(gameObject) { gameObject.addToWorld(this); },
-	addGameObject: function(entity) { this.gameObjects.push(entity); },
-	getGameObjects: function() { return this.gameObjects; }
+    /*
+     * Manage GameObjects
+     */
+    spawn: function(gameObject) { gameObject.addToWorld(this); },
+    addGameObject: function(entity) { this.gameObjects.push(entity); },
+    getGameObjects: function() { return this.gameObjects; }
 });
 
 Object.subclass("Map", {
-	initialize: function(tileSize, tiles) {
-	    this.tileSize = tileSize;
-		this.tiles = _.map(tiles, function(stripe) {
+    initialize: function(tileSize, tiles) {
+        this.tileSize = tileSize;
+        this.tiles = _.map(tiles, function(stripe) {
             return _.map(stripe, function(tileIndex) {
                 return new Tile(tileIndex);
             });
         });
         this.spriteSheet = new AnimationSheet("assets/tileset.png", 32, 32);
-	},
+    },
 
-	draw: function(renderer) {
-		_.each(this.tiles, function(stripe, y) {
+    draw: function(renderer) {
+        _.each(this.tiles, function(stripe, y) {
             _.each(stripe, function(tile, x) {
                 var min = new Vector2(x, y).mulVector(this.tileSize);
                 this.spriteSheet.draw(
@@ -69,13 +69,13 @@ Object.subclass("Map", {
                     tile.index
                 );
             }, this);
-		}, this);
-	}
+        }, this);
+    }
 });
 
 Object.subclass("Tile", {
-	initialize: function(index) {
-		this.index = index;
-	}
+    initialize: function(index) {
+        this.index = index;
+    }
 });
 

--- a/vanoverveld/sketchpad.js
+++ b/vanoverveld/sketchpad.js
@@ -10,26 +10,26 @@ module('users.timfelgentreff.vanoverveld.sketchpad').requires().toRun(function()
 
 // Object.addMethods({
 //     get __id() {
-//     	if (!this.hasOwnProperty('___id'))
-//     	    this.___id = Object.__idCtr++
-//     	return this.___id
+//         if (!this.hasOwnProperty('___id'))
+//             this.___id = Object.__idCtr++
+//         return this.___id
 //     },
 //     get __type() {
-//     	if (!this.hasOwnProperty('___type'))
-//     	    this.___type = this.constructor.name.replace(/__/g, '.')
-//     	return this.___type
+//         if (!this.hasOwnProperty('___type'))
+//             this.___type = this.constructor.name.replace(/__/g, '.')
+//         return this.___type
 //     },
 //     get __shortType() {
-//     	var res = this.__type
-//     	return res.substring(res.lastIndexOf('.') + 1)
+//         var res = this.__type
+//         return res.substring(res.lastIndexOf('.') + 1)
 //     },
 //     get __toString() {
-// 	    return this.__shortType + '@' + this.__id
+//         return this.__shortType + '@' + this.__id
 //     },
 //     get __scratch() {
-//     	if (!this.hasOwnProperty('___scratch'))
-//     	    this.___scratch = {}
-//     	return this.___scratch
+//         if (!this.hasOwnProperty('___scratch'))
+//             this.___scratch = {}
+//         return this.___scratch
 //     }
 // });
 
@@ -56,7 +56,7 @@ Sketchpad.prototype.addClass = function(aClass, isConstraint) {
 Sketchpad.prototype.markObjectWithIdIfNew = function(obj) {
     var id = obj.__id
     if (this.objMap[id])
-	return true
+    return true
     this.objMap[id] = obj
     return false
 }
@@ -67,23 +67,23 @@ Sketchpad.prototype.getObject = function(id) {
 
 Sketchpad.prototype.addConstraint = function(constraint) {
     if (!constraint.__priority)
-	constraint.__priority = 0
+    constraint.__priority = 0
     //this.constraints.push(constraint)
     var prio = constraint.__priority
     var addIdx = 0
     while (addIdx < this.constraints.length && this.constraints[addIdx].__priority < prio)
-	addIdx++
+    addIdx++
     if (this.solveEvenWithoutErrorOnPriorityDifferences) {
-	this.addToPerThingPerPropertyEffectorsForConstraint(constraint, this.perThingPerPropEffectingConstraints)
-	this.computeConstraintsCompetingWithALowerPriorityOneForConstraint(constraint)
+    this.addToPerThingPerPropertyEffectorsForConstraint(constraint, this.perThingPerPropEffectingConstraints)
+    this.computeConstraintsCompetingWithALowerPriorityOneForConstraint(constraint)
     }
     this.constraints.splice(addIdx, 0, constraint)
     for (var p in constraint) {
-	if (constraint.hasOwnProperty(p)) {
-	    var obj = constraint[p]
-	    if (obj !== undefined && !this.objMap[obj.__id])
-		this.objMap[obj.__id] = obj
-	}
+    if (constraint.hasOwnProperty(p)) {
+        var obj = constraint[p]
+        if (obj !== undefined && !this.objMap[obj.__id])
+        this.objMap[obj.__id] = obj
+    }
     }
     return constraint
 }
@@ -91,11 +91,11 @@ Sketchpad.prototype.addConstraint = function(constraint) {
 Sketchpad.prototype.removeConstraint = function(unwantedConstraint) {
     var self = this
     this.constraints = this.constraints.filter(function(constraint) {
-	return constraint !== unwantedConstraint &&
+    return constraint !== unwantedConstraint &&
             !(involves(constraint, unwantedConstraint))
     })
     if (this.solveEvenWithoutErrorOnPriorityDifferences)
-	this.computePerThingPerPropertyEffectors()
+    this.computePerThingPerPropertyEffectors()
 }
 
 Sketchpad.prototype.clear = function() {
@@ -117,7 +117,7 @@ Sketchpad.prototype.clear = function() {
     this.scratch = {}
     // remove existing event handlers
     for (var name in this.eventHandlersInternal)
-	this.eventHandlersInternal[name].forEach(function(handler) { document.body.removeEventListener(name, handler) })
+    this.eventHandlersInternal[name].forEach(function(handler) { document.body.removeEventListener(name, handler) })
     this.eventHandlersInternal = {}
     this.eventDescriptions = {}
     this.onEachTimeStepHandlerDescriptions = {}
@@ -128,9 +128,9 @@ Sketchpad.prototype.computeCurrentError = function() {
     var prevPseudoTime = this.prevPseudoTime 
     var totalError = 0
     for (var idx = 0; idx < this.constraints.length; idx++) {
-	var c = this.constraints[idx]
-	var er = Math.abs(c.computeError(pseudoTime, prevPseudoTime))	
-	totalError += er
+    var c = this.constraints[idx]
+    var er = Math.abs(c.computeError(pseudoTime, prevPseudoTime))    
+    totalError += er
     }
     return totalError
 }
@@ -142,26 +142,26 @@ Sketchpad.prototype.collectPerConstraintSolutions = function(timeMillis, inFixPo
     var allSolutions = []
     var didSomething = false, localDidSomething = false, totalError = 0
     for (var idx = 0; idx < this.constraints.length; idx++) {
-	var c = this.constraints[idx]
-	var searchable = c.__searchable
-	if (inFixPointProcess && searchable)
-	    continue
-	var er = Math.abs(c.computeError(pseudoTime, prevPseudoTime))	
-	totalError += er
-	if (er > self.epsilon
-	    || this.solveEvenWithoutError || (this.solveEvenWithoutErrorOnPriorityDifferences && this.constraintIsCompetingWithALowerPriorityOne(c))
-	   ) {
-	    var solutions = c.solve(pseudoTime, prevPseudoTime)
-	    if (!(inFixPointProcess || searchable))
-		solutions = [solutions]
-	    localDidSomething = true
-	    allSolutions.push({constraint: c, solutions: solutions})
-	}
+    var c = this.constraints[idx]
+    var searchable = c.__searchable
+    if (inFixPointProcess && searchable)
+        continue
+    var er = Math.abs(c.computeError(pseudoTime, prevPseudoTime))    
+    totalError += er
+    if (er > self.epsilon
+        || this.solveEvenWithoutError || (this.solveEvenWithoutErrorOnPriorityDifferences && this.constraintIsCompetingWithALowerPriorityOne(c))
+       ) {
+        var solutions = c.solve(pseudoTime, prevPseudoTime)
+        if (!(inFixPointProcess || searchable))
+        solutions = [solutions]
+        localDidSomething = true
+        allSolutions.push({constraint: c, solutions: solutions})
+    }
     }
     if (localDidSomething) {
-	didSomething = true
+    didSomething = true
     } else
-	totalError = 0
+    totalError = 0
     return {didSomething: didSomething, error: totalError, solutions: allSolutions}
 }
 
@@ -169,21 +169,21 @@ Sketchpad.prototype.collectPerPropertySolutions = function(allSolutions) {
     var self = this
     var collectedSolutions = {}, seenPriorities = {}
     allSolutions.forEach(function(d) {
-	collectPerPropertySolutionsAddSolution(self, d, collectedSolutions, seenPriorities)
+    collectPerPropertySolutionsAddSolution(self, d, collectedSolutions, seenPriorities)
     })
     return collectedSolutions
 }
 
 Sketchpad.prototype.doOneIteration = function(timeMillis) {
     if (this.beforeEachIteration)
-	(this.beforeEachIteration)()
+    (this.beforeEachIteration)()
     var res = this.collectPerConstraintSolutions(timeMillis, true)
     var didSomething = res.didSomething
     var totalError = res.error
     if (didSomething) {
-	var allSolutions = res.solutions
-	var collectedSolutions = this.collectPerPropertySolutions(allSolutions)
-	applySolutions(this, collectedSolutions)
+    var allSolutions = res.solutions
+    var collectedSolutions = this.collectPerPropertySolutions(allSolutions)
+    applySolutions(this, collectedSolutions)
     }
     return totalError
 }
@@ -191,7 +191,7 @@ Sketchpad.prototype.doOneIteration = function(timeMillis) {
 Sketchpad.prototype.computePerThingPerPropertyEffectors = function() {
     var res = {}
     this.constraints.forEach(function(c) {
-	this.addToPerThingPerPropertyEffectorsForConstraint(c, res)
+    this.addToPerThingPerPropertyEffectorsForConstraint(c, res)
     }.bind(this))
     this.perThingPerPropEffectingConstraints = res  
     this.computeConstraintsCompetingWithALowerPriorityOne()
@@ -199,26 +199,26 @@ Sketchpad.prototype.computePerThingPerPropertyEffectors = function() {
 
 Sketchpad.prototype.addToPerThingPerPropertyEffectorsForConstraint = function(c, res) {
     if (c.effects) {
-	c.effects().forEach(function(e) { 
-	    var id = e.obj.__id
-	    var eProps = e.props
-	    var props, cs
-	    if (res[id])
-		props = res[id]
-	    else {
-		props = {}
-		res[id] = props
-	    }
-	    eProps.forEach(function(prop) {
-		if (props[prop])
-		    cs = props[prop]
-		else {
-		    cs = []
-		    props[prop] = cs
-		}
-		cs.push(c)		
-	    })
-	})	    
+    c.effects().forEach(function(e) { 
+        var id = e.obj.__id
+        var eProps = e.props
+        var props, cs
+        if (res[id])
+        props = res[id]
+        else {
+        props = {}
+        res[id] = props
+        }
+        eProps.forEach(function(prop) {
+        if (props[prop])
+            cs = props[prop]
+        else {
+            cs = []
+            props[prop] = cs
+        }
+        cs.push(c)        
+        })
+    })        
     }
 }
 
@@ -228,25 +228,25 @@ Sketchpad.prototype.constraintIsCompetingWithALowerPriorityOne = function(constr
 
 Sketchpad.prototype.computeConstraintsCompetingWithALowerPriorityOneForConstraint = function(constraint) {
     for (var id in this.perThingPerPropEffectingConstraints) {
-	var thingEffs = this.perThingPerPropEffectingConstraints[id]
-	for (var p in thingEffs) {
-	    var cs = thingEffs[p]
-	    if (cs.indexOf(constraint) >= 0) {
-		for (var i = 0; i < cs.length; i++) {
-		    var c = cs[i]
-		    if (c !== constraint && c.__priority < constraint.__priority) {
-			this.computeConstraintsCompetingWithALowerPriorityOne[constraint.__id] = true
-			return
-		    }
-		}
-	    }
-	}
+    var thingEffs = this.perThingPerPropEffectingConstraints[id]
+    for (var p in thingEffs) {
+        var cs = thingEffs[p]
+        if (cs.indexOf(constraint) >= 0) {
+        for (var i = 0; i < cs.length; i++) {
+            var c = cs[i]
+            if (c !== constraint && c.__priority < constraint.__priority) {
+            this.computeConstraintsCompetingWithALowerPriorityOne[constraint.__id] = true
+            return
+            }
+        }
+        }
+    }
     }
 }
 
 Sketchpad.prototype.computeConstraintsCompetingWithALowerPriorityOne = function() {    
     this.constraints.forEach(function(constraint) {    
-	this.computeConstraintsCompetingWithALowerPriorityOneForConstraint(constraint)
+    this.computeConstraintsCompetingWithALowerPriorityOneForConstraint(constraint)
     }.bind(this))
 }
 
@@ -258,22 +258,22 @@ Sketchpad.prototype.doTasksOnEachTimeStep = function(pseudoTime, prevPseudoTime)
     this.handleEvents()
     this.doOnEachTimeStepFns(pseudoTime, prevPseudoTime)
     if (this.onEachTimeStep) 
-	(this.onEachTimeStep)(pseudoTime, prevPseudoTime)
+    (this.onEachTimeStep)(pseudoTime, prevPseudoTime)
 }
 
 Sketchpad.prototype.doTasksAfterEachTimeStep = function(pseudoTime, prevPseudoTime) {
     this.doAfterEachTimeStepFns(pseudoTime, prevPseudoTime)
     if (this.afterEachTimeStep) 
-	(this.afterEachTimeStep)(pseudoTime, prevPseudoTime)
+    (this.afterEachTimeStep)(pseudoTime, prevPseudoTime)
     this.maybeStepPseudoTime()
 }
 
 Sketchpad.prototype.computeNextPseudoTimeFromProposals = function(pseudoTime, proposals) {
     var res = proposals[0].time
     for (var i = 1; i < proposals.length; i++) {
-	time = proposals[i].time
-	if (time < res)
-	    res = time
+    time = proposals[i].time
+    if (time < res)
+        res = time
     }
     return res
 }
@@ -288,7 +288,7 @@ Sketchpad.prototype.maybeStepPseudoTime = function() {
             proposals.push({proposer: t, time: t.proposeNextPseudoTime(pseudoTime)})
     })
     if (proposals.length > 0)
-	this.pseudoTime = this.computeNextPseudoTimeFromProposals(pseudoTime, proposals)	
+    this.pseudoTime = this.computeNextPseudoTimeFromProposals(pseudoTime, proposals)    
 }
 
 Sketchpad.prototype.iterateSearchChoicesForUpToMillis = function(timeMillis) {
@@ -298,42 +298,42 @@ Sketchpad.prototype.iterateSearchChoicesForUpToMillis = function(timeMillis) {
     var totalError = sols.error
     var res = {error: totalError, count: 0} //FIXME
     if (didSomething) {
-	var allSolutionChoices = sols.solutions
-	//find all solution combinations between constraints
-	//log(allSolutionChoices)
-	var choicesCs = allSolutionChoices.map(function(c) { return c.constraint })
-	var cCount = choicesCs.length
-	var choicesSs = allSolutionChoices.map(function(c) { return c.solutions })
-	var allSolutionCombos = allCombinationsOfArrayElements(choicesSs).map(function(combo) {	    
-	    var curr = []
-	    for (var i = 0; i < cCount; i++) {
-		curr.push({constraint: choicesCs[i], solutions: combo[i]})
-	    }
-	    return curr
-	})
-	//log(allSolutionCombos)
-	// copy curr state and try one, if works return else revert state move to next until none left
-	var count = allSolutionCombos.length
-	var choiceTO = timeMillis / count
-	if (this.debug) log('possible choices', count, 'per choice timeout', choiceTO)
-	for (var i = 0; i < count; i++) {
-	    var copied, last = i == count - 1
-	    if (this.debug) log('trying choice: ' + i)
-	    var allSolutions = allSolutionCombos[i]
-	    //log(allSolutions)
-	    var collectedSolutions = this.collectPerPropertySolutions(allSolutions)
-	    //copy here...	    
-	    if (!last)
-		copied = this.getCurrentPropValuesAffectableBySolutions(collectedSolutions)
-	    applySolutions(this, collectedSolutions)
-	    res = this.iterateForUpToMillis(choiceTO)	    
-	    var choiceErr = this.computeCurrentError()
-	    //log(choiceErr)
-	    if (choiceErr < epsilon || last)
-		break
-	    //revert here
-	    this.revertPropValuesBasedOnArg(copied)
-	}
+    var allSolutionChoices = sols.solutions
+    //find all solution combinations between constraints
+    //log(allSolutionChoices)
+    var choicesCs = allSolutionChoices.map(function(c) { return c.constraint })
+    var cCount = choicesCs.length
+    var choicesSs = allSolutionChoices.map(function(c) { return c.solutions })
+    var allSolutionCombos = allCombinationsOfArrayElements(choicesSs).map(function(combo) {        
+        var curr = []
+        for (var i = 0; i < cCount; i++) {
+        curr.push({constraint: choicesCs[i], solutions: combo[i]})
+        }
+        return curr
+    })
+    //log(allSolutionCombos)
+    // copy curr state and try one, if works return else revert state move to next until none left
+    var count = allSolutionCombos.length
+    var choiceTO = timeMillis / count
+    if (this.debug) log('possible choices', count, 'per choice timeout', choiceTO)
+    for (var i = 0; i < count; i++) {
+        var copied, last = i == count - 1
+        if (this.debug) log('trying choice: ' + i)
+        var allSolutions = allSolutionCombos[i]
+        //log(allSolutions)
+        var collectedSolutions = this.collectPerPropertySolutions(allSolutions)
+        //copy here...        
+        if (!last)
+        copied = this.getCurrentPropValuesAffectableBySolutions(collectedSolutions)
+        applySolutions(this, collectedSolutions)
+        res = this.iterateForUpToMillis(choiceTO)        
+        var choiceErr = this.computeCurrentError()
+        //log(choiceErr)
+        if (choiceErr < epsilon || last)
+        break
+        //revert here
+        this.revertPropValuesBasedOnArg(copied)
+    }
     }
     return res
 }
@@ -341,34 +341,34 @@ Sketchpad.prototype.iterateSearchChoicesForUpToMillis = function(timeMillis) {
 Sketchpad.prototype.getCurrentPropValuesAffectableBySolutions = function(solutions) {
     var res = {}
     for (var objId in solutions) {
-	var currObj = sketchpad.objMap[objId]
-	var propsN = {}
-	res[objId] = propsN
-	var props = solutions[objId]
-	for (var p in props) {
-	    propsN[p] = currObj[p]
-	}
+    var currObj = sketchpad.objMap[objId]
+    var propsN = {}
+    res[objId] = propsN
+    var props = solutions[objId]
+    for (var p in props) {
+        propsN[p] = currObj[p]
+    }
     }
     return res
 }
 
 Sketchpad.prototype.revertPropValuesBasedOnArg = function(values) {
     for (var objId in values) {
-	var currObj = sketchpad.objMap[objId]
-	var props = values[objId]
-	for (var p in props) {
-	    currObj[p] = props[p]
-	}
+    var currObj = sketchpad.objMap[objId]
+    var props = values[objId]
+    for (var p in props) {
+        currObj[p] = props[p]
+    }
     }
 }
 
 Sketchpad.prototype.solveForUpToMillis = function(tMillis) {
     this.doTasksOnEachTimeStep(this.pseudoTime, this.prevPseudoTime)
     var res
-    if (this.searchOn)	
-	res = this.iterateSearchChoicesForUpToMillis(tMillis)
+    if (this.searchOn)    
+    res = this.iterateSearchChoicesForUpToMillis(tMillis)
     else
-	res = this.iterateForUpToMillis(tMillis)
+    res = this.iterateForUpToMillis(tMillis)
     this.doTasksAfterEachTimeStep(this.pseudoTime, this.prevPseudoTime)
     return res
 }
@@ -379,17 +379,17 @@ Sketchpad.prototype.iterateForUpToMillis = function(tMillis) {
     var t0, t
     t0 = this.currentTime()
     do {
-	lastError = currError
-	currError = this.doOneIteration(t0)
-	t =  this.currentTime() - t0
-	if (currError > 0) {
-	    count++
-	    totalError += currError
-	}
+    lastError = currError
+    currError = this.doOneIteration(t0)
+    t =  this.currentTime() - t0
+    if (currError > 0) {
+        count++
+        totalError += currError
+    }
     } while (
-	currError > epsilon
-	    && !(currError >= lastError)
-	    && t < tMillis)
+    currError > epsilon
+        && !(currError >= lastError)
+        && t < tMillis)
     return {error: totalError, count: count}
 }
 
@@ -430,8 +430,8 @@ Sketchpad.prototype.registerEvent = function(name, callback, optDescription) {
     this.eventHandlers.push(callback)
     var handler = function(e) { this.events.push([id, e]) }.bind(this)
     if (!this.eventHandlersInternal[name]) {
-	this.eventHandlersInternal[name] = []
-	this.eventDescriptions[name] = []
+    this.eventHandlersInternal[name] = []
+    this.eventDescriptions[name] = []
     }
     this.eventHandlersInternal[name].push(handler)
     this.eventDescriptions[name].push(optDescription)
@@ -440,11 +440,11 @@ Sketchpad.prototype.registerEvent = function(name, callback, optDescription) {
 
 Sketchpad.prototype.handleEvents = function() {
     this.events.forEach(function(nameAndE) { 
-	var id = nameAndE[0]; 
-	var e = nameAndE[1]; 
-	var h = this.eventHandlers[id]
-	if (h !== undefined)
-	    h(e) 
+    var id = nameAndE[0]; 
+    var e = nameAndE[1]; 
+    var h = this.eventHandlers[id]
+    if (h !== undefined)
+        h(e) 
     }.bind(this))
     this.events = []
 }
@@ -460,7 +460,7 @@ Sketchpad.prototype.doAfterEachTimeStepFns = function(pseudoTime, prevPseudoTime
 Sketchpad.prototype.setOnEachTimeStep = function(onEachTimeFn, optDescription) {
     this.onEachTimeStep = onEachTimeFn
     if (optDescription)
-	this.onEachTimeStepHandlerDescriptions['general'] = [optDescription]
+    this.onEachTimeStepHandlerDescriptions['general'] = [optDescription]
 }
 
 Sketchpad.prototype.unsetOnEachTimeStep = function() {
@@ -475,40 +475,40 @@ function collectPerPropertySolutionsAddSolution(sketchpad, soln, sofar, seenPrio
     var c = soln.constraint
     var priority = c.__priority
     for (var obj in soln.solutions) {
-	var currObj = c[obj]
-	var currObjId = currObj.__id
-	var d = soln.solutions[obj]
-	var keys = Object.keys(d)
-	for (var i = 0; i < keys.length; i++) {
-	    var prop = keys[i]
-	    var perPropSoln = sofar[currObjId]
-	    var perPropPrio = seenPriorities[currObjId]
-	    var propSolns, prio
-	    if (perPropSoln === undefined) {
-		perPropSoln = {}
-		perPropPrio = {}
-		sofar[currObjId] = perPropSoln
-		seenPriorities[currObjId] = perPropPrio
-		propSolns = []
-		perPropSoln[prop] = propSolns
-		perPropPrio[prop] = priority
-	    } else {		    
-		propSolns = perPropSoln[prop]
-		if (propSolns === undefined) {
-		    propSolns = []
-		    perPropSoln[prop] = propSolns
-		    perPropPrio[prop] = priority
-		}
-	    }
-	    var lastPrio = perPropPrio[prop]
-	    if (priority > lastPrio) {
-		perPropPrio[prop] = priority
-		while (propSolns.length > 0) propSolns.pop()
-	    } else if (priority < lastPrio) {
-		break
-	    } 
-	    propSolns.push(d[prop])
-	}
+    var currObj = c[obj]
+    var currObjId = currObj.__id
+    var d = soln.solutions[obj]
+    var keys = Object.keys(d)
+    for (var i = 0; i < keys.length; i++) {
+        var prop = keys[i]
+        var perPropSoln = sofar[currObjId]
+        var perPropPrio = seenPriorities[currObjId]
+        var propSolns, prio
+        if (perPropSoln === undefined) {
+        perPropSoln = {}
+        perPropPrio = {}
+        sofar[currObjId] = perPropSoln
+        seenPriorities[currObjId] = perPropPrio
+        propSolns = []
+        perPropSoln[prop] = propSolns
+        perPropPrio[prop] = priority
+        } else {            
+        propSolns = perPropSoln[prop]
+        if (propSolns === undefined) {
+            propSolns = []
+            perPropSoln[prop] = propSolns
+            perPropPrio[prop] = priority
+        }
+        }
+        var lastPrio = perPropPrio[prop]
+        if (priority > lastPrio) {
+        perPropPrio[prop] = priority
+        while (propSolns.length > 0) propSolns.pop()
+        } else if (priority < lastPrio) {
+        break
+        } 
+        propSolns.push(d[prop])
+    }
     }
 }
 
@@ -516,46 +516,46 @@ function applySolutions(sketchpad, solutions) {
     //log2(solutions)
     var keys1 = Object.keys(solutions)
     for (var i = 0; i < keys1.length; i++) {
-	var objId = keys1[i]
-	var perProp = solutions[objId]
-	var currObj = sketchpad.objMap[objId]
-	var keys2 = Object.keys(perProp)
-	for (var j = 0; j < keys2.length; j++) {
-	    var prop = keys2[j]
-	    var propSolns = perProp[prop]
-	    var currVal = currObj[prop]
-	    var joinFn = (currObj.solutionJoins !== undefined && (currObj.solutionJoins())[prop] !== undefined) ?
-		(currObj.solutionJoins())[prop] : sketchpad.sumJoinSolutions
-	    currObj[prop] = (joinFn.bind(sketchpad))(currVal, propSolns)
-	}
+    var objId = keys1[i]
+    var perProp = solutions[objId]
+    var currObj = sketchpad.objMap[objId]
+    var keys2 = Object.keys(perProp)
+    for (var j = 0; j < keys2.length; j++) {
+        var prop = keys2[j]
+        var propSolns = perProp[prop]
+        var currVal = currObj[prop]
+        var joinFn = (currObj.solutionJoins !== undefined && (currObj.solutionJoins())[prop] !== undefined) ?
+        (currObj.solutionJoins())[prop] : sketchpad.sumJoinSolutions
+        currObj[prop] = (joinFn.bind(sketchpad))(currVal, propSolns)
+    }
     }
 }
 
 function involves(constraint, obj) {
     for (var p in constraint) {
-	if (constraint[p] === obj) {
-	    return true
-	}
+    if (constraint[p] === obj) {
+        return true
+    }
     }
     return false
 }
 
 function allCombinationsOfArrayElements(arrayOfArrays) {
     if (arrayOfArrays.length > 1) {
-	var first = arrayOfArrays[0]
-	var rest = allCombinationsOfArrayElements(arrayOfArrays.slice(1))
-	var res = []
-	for (var j = 0; j < rest.length ; j++) {
-	    var r = rest[j]
-	    for (var i = 0; i < first.length; i++) {
-		res.push([first[i]].concat(r))
-	    }
-	}
-	return res
+    var first = arrayOfArrays[0]
+    var rest = allCombinationsOfArrayElements(arrayOfArrays.slice(1))
+    var res = []
+    for (var j = 0; j < rest.length ; j++) {
+        var r = rest[j]
+        for (var i = 0; i < first.length; i++) {
+        res.push([first[i]].concat(r))
+        }
+    }
+    return res
     }  else if (arrayOfArrays.length == 1) {
-	return arrayOfArrays[0].map(function(e) { return [e] })
+    return arrayOfArrays[0].map(function(e) { return [e] })
     } else
-	return []
+    return []
 }
 
 }) // end of module


### PR DESCRIPTION
Replaces all tabs with 4 spaces in files with mixed indentation
Not sure whether this should actually be done in the main repository, because if done this way it will show in our PR diff when merging back from this fork
- [ ] What about tabs-only files? Some examples now consist of spaces-only and tabs-only files
